### PR TITLE
Fix error on docker image build when a local config file is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY data /var/www/data
 
 # Reset "local"/development config files
 RUN rm -f /var/www/config/development.config.php && \
-  rm /var/www/config/autoload/*.local.php && \
+  rm -f /var/www/config/autoload/*.local.php && \
   mv /var/www/config/autoload/local.php.dist /var/www/config/autoload/local.php
 
 # Build project


### PR DESCRIPTION
If no local configuration file exists in the `config/autoload` directory, there is nothing to delete, actually. So, this triggers an error during `docker-compose build`:
> rm: can't remove '/var/www/config/autoload/*.local.php': No such file or directory