### PR TITLE
clean up HomePageHandler dependencies

### DIFF
--- a/src/App/Handler/HomePageHandler.php
+++ b/src/App/Handler/HomePageHandler.php
@@ -8,34 +8,22 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response\HtmlResponse;
-use Zend\Expressive\Router;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class HomePageHandler implements RequestHandlerInterface
 {
-    /** @var string */
-    private $containerName;
+    /** @var TemplateRendererInterface */
+    private $renderer;
 
-    /** @var Router\RouterInterface */
-    private $router;
-
-    /** @var null|TemplateRendererInterface */
-    private $template;
-
-    public function __construct(
-        string $containerName,
-        Router\RouterInterface $router,
-        ?TemplateRendererInterface $template = null
-    ) {
-        $this->containerName = $containerName;
-        $this->router        = $router;
-        $this->template      = $template;
+    public function __construct(TemplateRendererInterface $renderer)
+    {
+        $this->renderer = $renderer;
     }
 
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         return new HtmlResponse(
-            $this->template->render('app::home-page')
+            $this->renderer->render('app::home-page')
         );
     }
 }

--- a/src/App/Handler/HomePageHandlerFactory.php
+++ b/src/App/Handler/HomePageHandlerFactory.php
@@ -5,21 +5,12 @@ declare(strict_types=1);
 namespace App\Handler;
 
 use Psr\Container\ContainerInterface;
-use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
-
-use function get_class;
 
 class HomePageHandlerFactory
 {
-    public function __invoke(ContainerInterface $container) : RequestHandlerInterface
+    public function __invoke(ContainerInterface $container) : HomePageHandler
     {
-        $router   = $container->get(RouterInterface::class);
-        $template = $container->has(TemplateRendererInterface::class)
-            ? $container->get(TemplateRendererInterface::class)
-            : null;
-
-        return new HomePageHandler(get_class($container), $router, $template);
+        return new HomePageHandler($container->get(TemplateRendererInterface::class));
     }
 }

--- a/test/AppTest/Handler/HomePageHandlerFactoryTest.php
+++ b/test/AppTest/Handler/HomePageHandlerFactoryTest.php
@@ -9,7 +9,6 @@ use App\Handler\HomePageHandlerFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class HomePageHandlerFactoryTest extends TestCase
@@ -20,26 +19,10 @@ class HomePageHandlerFactoryTest extends TestCase
     protected function setUp()
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $router = $this->prophesize(RouterInterface::class);
-
-        $this->container->get(RouterInterface::class)->willReturn($router);
     }
 
-    public function testFactoryWithoutTemplate()
+    public function testFactory()
     {
-        $factory = new HomePageHandlerFactory();
-        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
-
-        $this->assertInstanceOf(HomePageHandlerFactory::class, $factory);
-
-        $homePage = $factory($this->container->reveal());
-
-        $this->assertInstanceOf(HomePageHandler::class, $homePage);
-    }
-
-    public function testFactoryWithTemplate()
-    {
-        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
         $this->container
             ->get(TemplateRendererInterface::class)
             ->willReturn($this->prophesize(TemplateRendererInterface::class));

--- a/test/AppTest/Handler/HomePageHandlerTest.php
+++ b/test/AppTest/Handler/HomePageHandlerTest.php
@@ -11,8 +11,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
-use Zend\Diactoros\Response\JsonResponse;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class HomePageHandlerTest extends TestCase
@@ -20,30 +18,12 @@ class HomePageHandlerTest extends TestCase
     /** @var ContainerInterface|ObjectProphecy */
     protected $container;
 
-    /** @var RouterInterface|ObjectProphecy */
-    protected $router;
-
     protected function setUp()
     {
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->router    = $this->prophesize(RouterInterface::class);
     }
 
-    public function testReturnsJsonResponseWhenNoTemplateRendererProvided()
-    {
-        $homePage = new HomePageHandler(
-            get_class($this->container->reveal()),
-            $this->router->reveal(),
-            null
-        );
-        $response = $homePage->handle(
-            $this->prophesize(ServerRequestInterface::class)->reveal()
-        );
-
-        $this->assertInstanceOf(JsonResponse::class, $response);
-    }
-
-    public function testReturnsHtmlResponseWhenTemplateRendererProvided()
+    public function testReturnsHtmlResponse()
     {
         $renderer = $this->prophesize(TemplateRendererInterface::class);
         $renderer
@@ -51,8 +31,6 @@ class HomePageHandlerTest extends TestCase
             ->willReturn('');
 
         $homePage = new HomePageHandler(
-            get_class($this->container->reveal()),
-            $this->router->reveal(),
             $renderer->reveal()
         );
 


### PR DESCRIPTION
Like other handlers, the HomePageHandler only require `TemplateRendererInterface` instance.