### PR TITLE
add missing col element for headlines within row

### DIFF
--- a/src/Blog/templates/list.phtml
+++ b/src/Blog/templates/list.phtml
@@ -13,7 +13,9 @@ $this->end();
 ?>
 <section class="blog container">
     <div class="row align-items-start mt-5">
-        <h1><?= $this->escapeHtml($title) ?></h1>
+        <div class="col">
+            <h1><?= $this->escapeHtml($title) ?></h1>
+        </div>
     </div>
 
     <?php if (empty($posts)) : ?>

--- a/src/Blog/templates/post.phtml
+++ b/src/Blog/templates/post.phtml
@@ -14,7 +14,9 @@ $this->end();
 ?>
 <div class="single-entry h-entry container">
     <div class="row align-items-start mt-5">
-        <h1><a href="<?= $this->url('blog') ?>">Blog</a></h1>
+        <div class="col">
+            <h1><a href="<?= $this->url('blog') ?>">Blog</a></h1>
+        </div>
     </div>
 
     <div class="row align-items-start mt-5">

--- a/templates/about/overview.phtml
+++ b/templates/about/overview.phtml
@@ -2,7 +2,9 @@
 
 <div class="container">
     <div class="row mt-5">
-        <h1>About</h1>
+        <div class="col">
+            <h1>About</h1>
+        </div>
     </div>
 
     <div class="row align-items-start mt-5">

--- a/templates/community/participate.phtml
+++ b/templates/community/participate.phtml
@@ -2,7 +2,9 @@
 
 <div class="container mt-5">
     <div class="row">
-        <h1>Community</h1>
+        <div class="col">
+            <h1>Community</h1>
+        </div>
     </div>
 
     <div class="row row-cols-1 row-cols-md-3">


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes negative margins on headlines:

![Bildschirmfoto von 2020-01-05 13-31-17](https://user-images.githubusercontent.com/2178371/71780239-5be23880-2fc0-11ea-9f02-e74b4b5c0d50.png)

Fixed:
![Bildschirmfoto von 2020-01-05 13-32-20](https://user-images.githubusercontent.com/2178371/71780240-613f8300-2fc0-11ea-82ee-286e7d83222d.png)


