### PR TITLE
Change link to "Components and MVC"

### DIFF
--- a/templates/layout/default.phtml
+++ b/templates/layout/default.phtml
@@ -54,7 +54,7 @@
                 <div class="col-md-4">
                     <h5 class="border-bottom border-white">Projects</h5>
                     <nav class="nav flex-column">
-                        <a class="nav-item" href="https://getlaminas.org/">Components and MVC</a>
+                        <a class="nav-item" href="https://docs.laminas.dev/">Components and MVC</a>
                         <a class="nav-item" href="https://docs.mezzio.dev/">Mezzio: PSR-15 Middleware in Minutes</a>
                         <a class="nav-item" href="https://api-tools.getlaminas.org/">Laminas API Tools</a>
                     </ul>


### PR DESCRIPTION
I think it is better to have link here to the docs.laminas.dev instead getlaminas.org.
