### PR TITLE
feat: display and update release feeds

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -40,6 +40,7 @@ hooks:
     composer build
   deploy: |
     rm -f data/cache/config-cache.php
+    if [ ! -e data/cache/releases.rss ];then cp templates/releases.rss data/cache/ ;fi
 
 crons:
     snapshot:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@ Source code for the getlaminas.org website.
 
 ## Testing
 
-To test the application, use the provided [docker-compose
-configuration](docker-compose.yml):
+First, create a `.env` file in the root directory with contents similar to the
+following:
+
+```env
+RELEASE_FEED_TOKEN=aaaabbbbccccddddeeeeffffgggg0000
+```
+
+Next, use the provided [docker-compose configuration](docker-compose.yml):
 
 ```bash
 $ docker-compose build

--- a/composer.json
+++ b/composer.json
@@ -40,26 +40,27 @@
     "require": {
         "php": "~7.2",
         "dflydev/fig-cookies": "^2.0",
+        "laminas/laminas-component-installer": "^2.1.1",
+        "laminas/laminas-config-aggregator": "^1.0",
+        "laminas/laminas-dependency-plugin": "^1.0",
+        "laminas/laminas-diactoros": "^1.7.1 || ^2.0",
+        "laminas/laminas-feed": "^2.12",
+        "laminas/laminas-paginator": "^2.8",
+        "laminas/laminas-servicemanager": "^3.3",
+        "laminas/laminas-stdlib": "^3.1",
         "league/commonmark": "^1.1",
+        "mezzio/mezzio": "^3.0.1",
+        "mezzio/mezzio-fastroute": "^3.0",
+        "mezzio/mezzio-helpers": "^5.0",
+        "mezzio/mezzio-platesrenderer": "^2.0",
+        "mezzio/mezzio-problem-details": "^1.1",
         "mnapoli/front-yaml": "^1.6",
         "monolog/monolog": "^1.24",
         "phly/phly-event-dispatcher": "^1.0",
         "phly/phly-expressive-configfactory": "^1.1",
         "symfony/console": "^4.0",
         "symfony/yaml": "^4.0",
-        "webuni/commonmark-table-extension": "^1.0",
-        "laminas/laminas-component-installer": "^2.1.1",
-        "laminas/laminas-config-aggregator": "^1.0",
-        "laminas/laminas-diactoros": "^1.7.1 || ^2.0",
-        "mezzio/mezzio": "^3.0.1",
-        "mezzio/mezzio-fastroute": "^3.0",
-        "mezzio/mezzio-helpers": "^5.0",
-        "mezzio/mezzio-platesrenderer": "^2.0",
-        "laminas/laminas-feed": "^2.12",
-        "laminas/laminas-paginator": "^2.8",
-        "laminas/laminas-servicemanager": "^3.3",
-        "laminas/laminas-stdlib": "^3.1",
-        "laminas/laminas-dependency-plugin": "^1.0"
+        "webuni/commonmark-table-extension": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0.1",
@@ -73,6 +74,7 @@
         "psr-4": {
             "App\\": "src/App/",
             "GetLaminas\\Blog\\": "src/Blog/",
+            "GetLaminas\\ReleaseFeed\\": "src/ReleaseFeed/",
             "GetLaminas\\Security\\": "src/Security/"
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30ca305a29247e4ea0aad4327cb56604",
+    "content-hash": "ae6446248eb8a91e1aee1c85f5bcf97b",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1347,6 +1347,68 @@
             "time": "2019-12-31T15:45:32+00:00"
         },
         {
+            "name": "mezzio/mezzio-problem-details",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mezzio/mezzio-problem-details.git",
+                "reference": "ae63964cdf9b6d6cacadf377bb5a8e40fa1a9910"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mezzio/mezzio-problem-details/zipball/ae63964cdf9b6d6cacadf377bb5a8e40fa1a9910",
+                "reference": "ae63964cdf9b6d6cacadf377bb5a8e40fa1a9910",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "fig/http-message-util": "^1.1.2",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.1",
+                "psr/container": "^1.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-middleware": "^1.0",
+                "spatie/array-to-xml": "^2.3",
+                "willdurand/negotiation": "^2.3"
+            },
+            "replace": {
+                "zendframework/zend-problem-details": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^7.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev",
+                    "dev-develop": "1.2.x-dev"
+                },
+                "laminas": {
+                    "config-provider": "Mezzio\\ProblemDetails\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Mezzio\\ProblemDetails\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Problem Details for PSR-7 HTTP APIs",
+            "homepage": "https://mezzio.dev",
+            "keywords": [
+                "api",
+                "laminas",
+                "mezzio",
+                "problem-details",
+                "rest"
+            ],
+            "time": "2019-12-31T15:45:41+00:00"
+        },
+        {
             "name": "mezzio/mezzio-router",
             "version": "3.1.1",
             "source": {
@@ -1734,6 +1796,7 @@
                 "config",
                 "expressive"
             ],
+            "abandoned": "phly/phly-configfactory",
             "time": "2019-02-07T14:46:47+00:00"
         },
         {
@@ -2085,6 +2148,56 @@
                 "psr-3"
             ],
             "time": "2019-11-01T11:05:21+00:00"
+        },
+        {
+            "name": "spatie/array-to-xml",
+            "version": "2.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "bdb5bc735b0639f6f438e935b13f7ac216239679"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/bdb5bc735b0639f6f438e935b13f7ac216239679",
+                "reference": "bdb5bc735b0639f6f438e935b13f7ac216239679",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^8.0",
+                "spatie/phpunit-snapshot-assertions": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://murze.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "time": "2019-08-21T06:32:31+00:00"
         },
         {
             "name": "symfony/console",
@@ -2513,6 +2626,58 @@
             ],
             "abandoned": "league/commonmark-ext-table",
             "time": "2019-07-09T13:34:17+00:00"
+        },
+        {
+            "name": "willdurand/negotiation",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/willdurand/Negotiation.git",
+                "reference": "03436ededa67c6e83b9b12defac15384cb399dc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/willdurand/Negotiation/zipball/03436ededa67c6e83b9b12defac15384cb399dc9",
+                "reference": "03436ededa67c6e83b9b12defac15384cb399dc9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Negotiation\\": "src/Negotiation"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "will+git@drnd.me"
+                }
+            ],
+            "description": "Content Negotiation tools for PHP provided as a standalone library.",
+            "homepage": "http://williamdurand.fr/Negotiation/",
+            "keywords": [
+                "accept",
+                "content",
+                "format",
+                "header",
+                "negotiation"
+            ],
+            "time": "2017-05-14T17:21:12+00:00"
         }
     ],
     "packages-dev": [

--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -1,5 +1,8 @@
 <?php
 return [
+    'release-feed' => [
+        'verification_token' => getenv('RELEASE_FEED_TOKEN'),
+    ],
     'blog' => [
         'db' => 'sqlite:' . realpath(getcwd()) . '/var/blog/posts.db',
     ],

--- a/config/config.php
+++ b/config/config.php
@@ -13,6 +13,7 @@ $cacheConfig = [
 ];
 
 $aggregator = new ConfigAggregator([
+    \Mezzio\ProblemDetails\ConfigProvider::class,
     \Laminas\Paginator\ConfigProvider::class,
     \Phly\EventDispatcher\ConfigProvider::class,
     \Laminas\HttpHandlerRunner\ConfigProvider::class,
@@ -34,6 +35,7 @@ $aggregator = new ConfigAggregator([
 
     // Default App module config
     GetLaminas\Blog\ConfigProvider::class,
+    GetLaminas\ReleaseFeed\ConfigProvider::class,
     GetLaminas\Security\ConfigProvider::class,
     App\ConfigProvider::class,
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -42,4 +42,7 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
 
     // Security advisory routes
     (new GetLaminas\Security\ConfigProvider())->registerRoutes($app, '/security');
+
+    // Release API
+    (new GetLaminas\ReleaseFeed\ConfigProvider())->registerRoutes($app);
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: 
       context: .
       dockerfile: .docker/php/Dockerfile
+    env_file:
+      - ./.env
     volumes:
       - .:/var/www
       - ./.docker/php/getlaminas.ini:/usr/local/etc/php/conf.d/999-getlaminas.ini

--- a/src/ReleaseFeed/Author.php
+++ b/src/ReleaseFeed/Author.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+class Author
+{
+    public $name;
+    public $uri;
+
+    public function __construct(
+        string $name,
+        string $uri
+    ) {
+        $this->name = $name;
+        $this->uri = $uri;
+    }
+
+    public function toArray()
+    {
+        return [
+            'name' => $this->name,
+            'uri'  => $this->uri,
+        ];
+    }
+}

--- a/src/ReleaseFeed/ConfigProvider.php
+++ b/src/ReleaseFeed/ConfigProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace GetLaminas\ReleaseFeed;
+
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Mezzio\Application;
+use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+class ConfigProvider
+{
+    public function __invoke() : array
+    {
+        return [
+            'dependencies' => $this->getDependencies(),
+            'release-feed' => [
+                'feed-file'          => getcwd() . '/data/cache/releases.rss',
+                'verification_token' => '',
+            ],
+        ];
+    }
+
+    public function getDependencies() : array
+    {
+        return [
+            'aliases' => [
+                ResponseFactoryInterface::class => ResponseFactory::class,
+                StreamFactoryInterface::class   => StreamFactory::class,
+            ],
+            'factories' => [
+                DisplayFeedHandler::class     => DisplayFeedHandlerFactory::class,
+                ReceiveFeedItemHandler::class => ReceiveFeedItemHandlerFactory::class,
+                ResponseFactory::class        => InvokableFactory::class,
+                StreamFactory::class          => InvokableFactory::class,
+                VerifyTokenMiddleware::class  => VerifyTokenMiddlewareFactory::class,
+            ],
+        ];
+    }
+
+    public function registerRoutes(Application $app) : void
+    {
+        $app->get('/releases/rss.xml', DisplayFeedHandler::class, 'releases.feed');
+        $app->post('/api/release', [
+            VerifyTokenMiddleware::class,
+            BodyParamsMiddleware::class,
+            ReceiveFeedItemHandler::class
+        ], 'api.release');
+    }
+}

--- a/src/ReleaseFeed/DisplayFeedHandler.php
+++ b/src/ReleaseFeed/DisplayFeedHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class DisplayFeedHandler implements RequestHandlerInterface
+{
+    /** @var string */
+    private $feedFile;
+
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    /** @var StreamFactoryInterface */
+    private $streamFactory;
+
+    public function __construct(
+        StreamFactoryInterface $streamFactory,
+        ResponseFactoryInterface $responseFactory,
+        string $feedFile
+    ) {
+        $this->streamFactory   = $streamFactory;
+        $this->responseFactory = $responseFactory;
+        $this->feedFile        = $feedFile;
+    }
+
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $body = $this->streamFactory->createStreamFromFile($this->feedFile, 'r');
+        return $this->responseFactory->createResponse(200)
+            ->withBody($body)
+            ->withHeader('Content-Type', 'application/rss+xml');
+    }
+}

--- a/src/ReleaseFeed/DisplayFeedHandlerFactory.php
+++ b/src/ReleaseFeed/DisplayFeedHandlerFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+class DisplayFeedHandlerFactory
+{
+    public function __invoke(ContainerInterface $container) : DisplayFeedHandler
+    {
+        return new DisplayFeedHandler(
+            $container->get(StreamFactoryInterface::class),
+            $container->get(ResponseFactoryInterface::class),
+            $container->get('config')['release-feed']['feed-file']
+        );
+    }
+}

--- a/src/ReleaseFeed/ReceiveFeedItemHandler.php
+++ b/src/ReleaseFeed/ReceiveFeedItemHandler.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use DateTimeImmutable;
+use Exception;
+use Laminas\Feed\Reader\Reader;
+use Laminas\Feed\Writer\Feed;
+use League\CommonMark\CommonMarkConverter;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+class ReceiveFeedItemHandler implements RequestHandlerInterface
+{
+    /** @var string */
+    private $feedFile;
+
+    /** @var CommonMarkConverter */
+    private $markdown;
+
+    /** @var ProblemDetailsResponseFactory */
+    private $problemFactory;
+
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    public function __construct(
+        string $feedFile,
+        CommonMarkConverter $markdown,
+        ResponseFactoryInterface $responseFactory,
+        ProblemDetailsResponseFactory $problemFactory
+    ) {
+        $this->feedFile        = $feedFile;
+        $this->markdown        = $markdown;
+        $this->responseFactory = $responseFactory;
+        $this->problemFactory  = $problemFactory;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $data = $request->getParsedBody();
+
+        if (! $this->validateData($data)) {
+            return $this->problemFactory->createResponse(
+                $request,
+                203,
+                'Malformed release provided'
+            );
+        }
+
+        $releases = $this->getCurrentReleases();
+        $releases->push($this->createRelease($data));
+
+        try {
+            $this->writeFeedToPath($this->createFeed($releases));
+        } catch (Exception $e) {
+            return $this->problemFactory->createResponse(
+                $request,
+                500,
+                sprintf('Error generating release feed: %s', $e->getMessage())
+            );
+        }
+
+        return $this->responseFactory->createResponse(204);
+    }
+
+    private function validateData(array $data) : bool
+    {
+        return isset(
+            $data['package'],
+            $data['version'],
+            $data['url'],
+            $data['changelog'],
+            $data['publication_date'],
+            $data['author_name'],
+            $data['author_url']
+        );
+    }
+
+    private function createRelease(array $data) : Release
+    {
+        return new Release(
+            $data['package'],
+            $data['version'],
+            $data['url'],
+            $this->markdown->convertToHtml($data['changelog']),
+            new DateTimeImmutable($data['publication_date']),
+            new Author($data['author_name'], $data['author_url'])
+        );
+    }
+
+    private function getCurrentReleases() : Releases
+    {
+        $xml      = file_get_contents($this->feedFile);
+        $feed     = Reader::importString($xml);
+        $releases = new Releases();
+
+        foreach ($feed as $entry) {
+            $title = $entry->getTitle();
+            list($package, $version) = explode(' ', $title);
+
+            $author = $entry->getAuthor();
+            $author = new Author($author['name'], $author['uri']);
+
+            $date = $entry->getDateCreated();
+
+            $releases->push(new Release(
+                $package,
+                $version,
+                $entry->getLink(),
+                $entry->getContent(),
+                $date,
+                $author
+            ));
+        }
+
+        return $releases;
+    }
+
+    private function createFeed(Releases $releases): Feed
+    {
+        $feed = new Feed();
+        $feed->setTitle('Laminas Project Releases');
+        $feed->setLink('https://getlaminas.org');
+        $feed->addAuthor([
+            'name' => 'Laminas Project',
+            'uri'  => 'https://getlaminas.org',
+        ]);
+        $feed->setDescription('Laminas Project releases, including components, MVC, API Tools, and Mezzio');
+
+        $latest = false;
+        foreach ($releases as $release) {
+            $latest = $latest ?: $release->date;
+
+            $entry = $feed->createEntry();
+            $entry->setTitle(sprintf('%s %s', $release->package, $release->version));
+            $entry->setLink($release->url);
+            $entry->addAuthor($release->author->toArray());
+            $entry->setDateCreated($release->date);
+            $entry->setDateModified($release->date);
+            $entry->setDescription(sprintf('Release information for %s %s', $release->package, $release->version));
+            $entry->setContent($release->content);
+
+            $feed->addEntry($entry);
+        }
+
+        $feed->setDateModified($latest);
+        $feed->setLastBuildDate($latest);
+
+        return $feed;
+    }
+
+    private function writeFeedToPath(Feed $feed): void
+    {
+        file_put_contents($this->feedFile, $feed->export('rss'), LOCK_EX);
+    }
+}

--- a/src/ReleaseFeed/ReceiveFeedItemHandlerFactory.php
+++ b/src/ReleaseFeed/ReceiveFeedItemHandlerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use League\CommonMark\CommonMarkConverter;
+use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+class ReceiveFeedItemHandlerFactory
+{
+    public function __invoke(ContainerInterface $container) : ReceiveFeedItemHandler
+    {
+        return new ReceiveFeedItemHandler(
+            $container->get('config')['release-feed']['feed-file'],
+            new CommonMarkConverter(),
+            $container->get(ResponseFactoryInterface::class),
+            $container->get(ProblemDetailsResponseFactory::class)
+        );
+    }
+}

--- a/src/ReleaseFeed/Release.php
+++ b/src/ReleaseFeed/Release.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use DateTimeInterface;
+
+class Release
+{
+    public $author;
+    public $content;
+    public $date;
+    public $package;
+    public $url;
+    public $version;
+
+    public function __construct(
+        string $package,
+        string $version,
+        string $url,
+        string $content,
+        DateTimeInterface $date,
+        Author $author
+    ) {
+        $this->package = $package;
+        $this->version = $version;
+        $this->url     = $url;
+        $this->content = $content;
+        $this->date    = $date;
+        $this->author  = $author;
+    }
+}

--- a/src/ReleaseFeed/Releases.php
+++ b/src/ReleaseFeed/Releases.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use ArrayIterator;
+use Iterator;
+use IteratorAggregate;
+
+class Releases implements IteratorAggregate
+{
+    private $releases = [];
+
+    public function getIterator(): Iterator
+    {
+        $releases = $this->sort($this->releases);
+        $releases = $this->truncate($releases);
+        return new ArrayIterator($releases);
+    }
+
+    public function push(Release $release): void
+    {
+        $this->releases[] = $release;
+    }
+
+    private function sort(array $releases): array
+    {
+        usort($releases, function (Release $a, Release $b) {
+            return $a->date <=> $b->date;
+        });
+        return array_reverse($releases);
+    }
+
+    private function truncate(array $releases): array
+    {
+        if (count($releases) < 30) {
+            return $releases;
+        }
+
+        return array_slice($releases, 0, 30);
+    }
+}

--- a/src/ReleaseFeed/VerifyTokenMiddleware.php
+++ b/src/ReleaseFeed/VerifyTokenMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class VerifyTokenMiddleware implements MiddlewareInterface
+{
+    /** ProblemDetailsResponseFactory */
+    private $problemFactory;
+
+    /** @var string */
+    private $token;
+
+    public function __construct(string $token, ProblemDetailsResponseFactory $problemFactory)
+    {
+        $this->token = $token;
+        $this->problemFactory = $problemFactory;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        $header = $request->getHeaderLine('Authorization');
+        if (! preg_match('/^token ' . $this->token . '/i', $header)) {
+            return $this->problemFactory->createResponse($request, 401, 'Missing or invalid authentication token');
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/ReleaseFeed/VerifyTokenMiddlewareFactory.php
+++ b/src/ReleaseFeed/VerifyTokenMiddlewareFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\ReleaseFeed;
+
+use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
+use Psr\Container\ContainerInterface;
+
+class VerifyTokenMiddlewareFactory
+{
+    public function __invoke(ContainerInterface $container) : VerifyTokenMiddleware
+    {
+        return new VerifyTokenMiddleware(
+            $container->get('config')['release-feed']['verification_token'],
+            $container->get(ProblemDetailsResponseFactory::class)
+        );
+    }
+}

--- a/templates/layout/default.phtml
+++ b/templates/layout/default.phtml
@@ -66,6 +66,7 @@
                         <a class="nav-item" href="<?= $this->url('about.overview') ?>">About</a>
                         <a class="nav-item" href="https://docs.laminas.dev">Documentation</a>
                         <a class="nav-item" href="<?= $this->url('blog') ?>">Blog</a>
+                        <a class="nav-item" href="<?= $this->url('releases.feed') ?>">Releases <span class="fas fa-rss-square"></span></a>
                         <a class="nav-item" href="<?= $this->url('security') ?>">Security</a>
                     </nav>
                 </div>

--- a/templates/releases.rss
+++ b/templates/releases.rss
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/">
+  <channel>
+    <title>Laminas Project Releases</title>
+    <description>Laminas Project releases, including components, MVC, API Tools, and Mezzio</description>
+    <pubDate>Tue, 31 Dec 2019 19:45:22 +0000</pubDate>
+    <lastBuildDate>Tue, 31 Dec 2019 19:45:22 +0000</lastBuildDate>
+    <generator>Laminas_Feed_Writer 2 (https://getlaminas.org)</generator>
+    <link>https://getlaminas.org/releases/rss.xml</link>
+    <author>Laminas Project</author>
+    <dc:creator>Laminas Project</dc:creator>
+    <atom:link rel="self" type="application/rss+xml" href="https://getlaminas.org/releases/rss.xml"/>
+  </channel>
+</rss>


### PR DESCRIPTION
This patch adds functionality for both displaying and updating the release feed.

The release feed will be updated via the API endpoint `/api/release`, which expects a JSON-encoded document to be submitted using the method POST, and containing the following keys:

- author_name (string)
- author_url (string)
- changelog (string)
- package (string)
- publication_date (RFC-formatted date-time string)
- url (string)
- version (string)

It will use that functionality to update the feed present in `data/cache/releases.rss`.

To safeguard this API, we will need to create a token and store it in the hosting environment; the API verifies that the token is present in the incoming request, and, if not, returns a 401 response.

The path `/releases/rss.xml` will serve the file `data/cache/releases.rss`.

On deployment, if no file resides at `data/cache/releases.rss`, an empty feed will be copied in from the `templates/releases.rss` file.