### PR TITLE
Link blog posts to their authors

### DIFF
--- a/data/blog/2020/2020-03-09-transferring-zf-to-laminas.md
+++ b/data/blog/2020/2020-03-09-transferring-zf-to-laminas.md
@@ -32,6 +32,8 @@ use [`replace` in `composer.json`](https://getcomposer.org/doc/04-schema.md#repl
 
 We needed a tool capable of much more than just "rewriting namespaces".
 
+<!--- EXTENDED -->
+
 ## Lifetime decisions
 
 ### Rewrite whole history or just tags?

--- a/src/Blog/BlogAuthor.php
+++ b/src/Blog/BlogAuthor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\Blog;
+
+class BlogAuthor
+{
+    /** @var string */
+    public $email;
+
+    /** @var string */
+    public $fullname;
+
+    /** @var string */
+    public $url;
+
+    /** @var string */
+    public $username;
+
+    public function __construct(
+        string $username,
+        string $fullname,
+        string $email,
+        string $url
+    ) {
+        $this->username = $username;
+        $this->fullname = $fullname;
+        $this->email    = $email;
+        $this->url      = $url;
+    }
+}

--- a/src/Blog/BlogPost.php
+++ b/src/Blog/BlogPost.php
@@ -12,7 +12,7 @@ use DateTimeInterface;
 
 class BlogPost
 {
-    /** @var string */
+    /** @var BlogAuthor */
     public $author;
 
     /** @var string */
@@ -45,7 +45,7 @@ class BlogPost
     public function __construct(
         string $id,
         string $title,
-        string $author,
+        BlogAuthor $author,
         DateTimeInterface $created,
         ?DateTimeInterface $updated,
         array $tags,

--- a/src/Blog/PlatesFunctionsDelegator.php
+++ b/src/Blog/PlatesFunctionsDelegator.php
@@ -11,8 +11,6 @@ class PlatesFunctionsDelegator implements ExtensionInterface
 {
     public $template;
 
-    private $engine;
-
     public function __invoke(ContainerInterface $container, $name, callable $factory)
     {
         $engine = $factory();
@@ -24,6 +22,7 @@ class PlatesFunctionsDelegator implements ExtensionInterface
     {
         $engine->registerFunction('formatDate', [$this, 'formatDate']);
         $engine->registerFunction('formatDateRfc', [$this, 'formatDateRfc']);
+        $engine->registerFunction('postAuthor', [$this, 'postAuthor']);
         $engine->registerFunction('postUrl', [$this, 'postUrl']);
     }
 
@@ -35,6 +34,16 @@ class PlatesFunctionsDelegator implements ExtensionInterface
     public function formatDateRfc(DateTimeInterface $date) : string
     {
         return $this->formatDate($date, 'c');
+    }
+
+    public function postAuthor(BlogPost $post) : string
+    {
+        $author = $post->author;
+        if ($author->url === '') {
+            return $author->fullname ?: $author->username;
+        }
+
+        return sprintf('<a href="%s" target="_blank">%s</a>', $author->url, $author->fullname ?: $author->username);
     }
 
     public function postUrl(BlogPost $post) : string

--- a/src/Blog/templates/post.phtml
+++ b/src/Blog/templates/post.phtml
@@ -30,9 +30,10 @@ $this->end();
             </div>
         </article>
 
-        <aside class="col-md-4 d-none d-sm-block sidebar blog">
+        <aside class="col-md-4 d-sm-block sidebar blog">
             <p>
-                Written on <time class="dt-published" datetime="<?= $this->formatDateRfc($post->created) ?>"><?= $this->formatDate($post->created) ?></time>.
+                Written on <time class="dt-published" datetime="<?= $this->formatDateRfc($post->created) ?>"><?= $this->formatDate($post->created) ?></time><?= $post->author ? sprintf(' by %s', $this->postAuthor($post)) : '' ?>.
+
                 <?php if ($post->updated) : ?>
                 <br />Last updated on <time class="dt-updated" datetime="<?= $this->formatDateRfc($post->updated) ?>"><?= $this->formatDate($post->updated) ?></time>.
                 <?php endif ?>


### PR DESCRIPTION
Adds a new class, `BlogAuthor`. When creating a `BlogPost`, any class that composes the `CreateBlogPostFromDataArray` trait will pull author metadata from the appropriate YAML file and use it to create and compose a `BlogAuthor` instance as a property of `BlogPost`. If no metadata is found, it uses only the username, with the email address no-reply@getlaminas.org.

Code for seeding the database and creating RSS feeds has been updated to reflect the changes.