### PR TITLE
Removes "transition period" from home page

### DIFF
--- a/templates/app/home-page.phtml
+++ b/templates/app/home-page.phtml
@@ -11,22 +11,6 @@
 </div>
 
 <div class="container">
-    <div class="row align-items-start mb-5">
-        <div class="col"><div class="teardrop card bg-primary text-white">
-            <h2 class="card-header">Transition Period</h2>
-            <div class="card-body">
-                <p class="card-text">
-                    We're in the process of finishing our migration and launch,
-                    and things will be changing rapidly. While the code migration
-                    is complete, there's still some work being done on websites,
-                    finalizing the technical charter, and more. Please have patience
-                    while we finalize the transition — and thank you for supporting
-                    Laminas!
-                </p>
-            </div>
-        </div></div>
-    </div>
-
     <div class="row row-cols-1 row-cols-md-3">
         <div class="col mb-4">
             <div class="card h-100 border border-components rounded">


### PR DESCRIPTION
I bet we can finally finish "transition period" and remove the note from the official website.