### PR TITLE
Redirect incorrect feed URLs to proper locations

### DIFF
--- a/src/Blog/ConfigProvider.php
+++ b/src/Blog/ConfigProvider.php
@@ -43,6 +43,7 @@ class ConfigProvider
                 Console\TagCloud::class                         => Console\TagCloudFactory::class,
                 Handler\DisplayPostHandler::class               => Handler\DisplayPostHandlerFactory::class,
                 Handler\FeedHandler::class                      => Handler\FeedHandlerFactory::class,
+                Handler\FeedRedirectHandler::class              => Handler\FeedRedirectHandlerFactory::class,
                 Handler\ListPostsHandler::class                 => Handler\ListPostsHandlerFactory::class,
                 Handler\SearchHandler::class                    => Handler\SearchHandlerFactory::class,
                 Listener\FetchBlogPostFromMapperListener::class => Listener\FetchBlogPostFromMapperListenerFactory::class,
@@ -83,6 +84,7 @@ class ConfigProvider
         $app->get($basePath . '/tag/{tag:[^/]+}/{type:atom|rss}.xml', Handler\FeedHandler::class, 'blog.tag.feed');
         $app->get($basePath . '/tag/{tag:[^/]+}', Handler\ListPostsHandler::class, 'blog.tag');
         $app->get($basePath . '/{type:atom|rss}.xml', Handler\FeedHandler::class, 'blog.feed');
+        $app->get($basePath . '/feed-{type:atom|rss}.xml', Handler\FeedRedirectHandler::class, 'blog.feed-redirect');
         $app->get($basePath . '/search[/]', Handler\SearchHandler::class, 'blog.search');
     }
 }

--- a/src/Blog/Handler/FeedRedirectHandler.php
+++ b/src/Blog/Handler/FeedRedirectHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\Blog\Handler;
+
+use Mezzio\Helper\ServerUrlHelper;
+use Mezzio\Helper\UrlHelper;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class FeedRedirectHandler implements RequestHandlerInterface
+{
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    /** @var ServerUrlHelper */
+    private $serverUrl;
+
+    /** @var UrlHelper */
+    private $url;
+
+    public function __construct(
+        UrlHelper $url,
+        ServerUrlHelper $serverUrl,
+        ResponseFactoryInterface $responseFactory
+    ) {
+        $this->url             = $url;
+        $this->serverUrl       = $serverUrl;
+        $this->responseFactory = $responseFactory;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse(301)
+            ->withHeader(
+                'Location',
+                $this->serverUrl->generate($this->url->generate(
+                    'blog.feed',
+                    ['type' => $request->getAttribute('type', 'rss')]
+                ))
+            );
+    }
+}

--- a/src/Blog/Handler/FeedRedirectHandlerFactory.php
+++ b/src/Blog/Handler/FeedRedirectHandlerFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GetLaminas\Blog\Handler;
+
+use Mezzio\Helper\ServerUrlHelper;
+use Mezzio\Helper\UrlHelper;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+class FeedRedirectHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): FeedRedirectHandler
+    {
+        return new FeedRedirectHandler(
+            $container->get(UrlHelper::class),
+            $container->get(ServerUrlHelper::class),
+            $container->get(ResponseFactoryInterface::class)
+        );
+    }
+}


### PR DESCRIPTION
Per laminas/documentation-theme#38, we currently have published feed URLs to the wrong locations.

Until we rebuild all docs, it would be best if we redirect these to the correct location. Once we have, we can remove this functionality.