### PR TITLE
Added basic search engine optimization + enabled responsive fonts

### DIFF
--- a/bootstrap/scss/_custom-variables.scss
+++ b/bootstrap/scss/_custom-variables.scss
@@ -21,9 +21,10 @@ $theme-colors: (
 
 // Some example variables that you can uncomment:
 
-// Enabling shadows and gradients
+// Enabling shadows, gradients, responsive font
 $enable-shadows: true;
 $enable-gradients: true;
+$enable-responsive-font-sizes: true;
 
 // Changing the body background and text
 $body-bg: #ffffff;

--- a/templates/app/home-page.phtml
+++ b/templates/app/home-page.phtml
@@ -1,8 +1,8 @@
-<?php $this->layout('layout::default', ['title' => 'Laminas Project']) ?>
+<?php $this->layout('layout::default', ['title' => 'Home']) ?>
 
 <div class="jumbotron jumbotron-home-page text-center">
     <div class="lead-box">
-        <h1 class="text-primary">It's Here!</h1>
+        <h1 class="text-primary">Laminas Project, the enterprise-ready PHP Framework and components</h1>
 
         <h2 class="text-primary">
             A community-supported, open source continuation of Zend Framework.
@@ -32,7 +32,7 @@
                     </p>
 
                     <a class="btn btn-components" href="https://docs.laminas.dev">
-                        Learn more
+                        Laminas documentation
                     </a>
                 </div>
             </div>
@@ -56,7 +56,7 @@
                     </p>
 
                     <a class="btn btn-expressive" href="https://docs.mezzio.dev">
-                        Learn more
+                        Mezzio documentation
                     </a>
                 </div>
             </div>
@@ -79,7 +79,7 @@
                     </p>
 
                     <a class="btn btn-apigility" href="https://api-tools.getlaminas.org">
-                        Learn more
+                        API Tools documentation
                     </a>
                 </div>
             </div>

--- a/templates/layout/default.phtml
+++ b/templates/layout/default.phtml
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <?php $this->insert('layout::favicon') ?>
 
-    <title><?= $this->e($title) ?> - Laminas Project</title>
+    <title><?= $this->e($title) ?> - Laminas Project - Enterprise PHP Framework</title>
 
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.13.0/css/all.css" integrity="sha384-Bfad6CLCknfcloXFOyFnlgtENryhrpZCe29RTifKEixXQZ38WheV+i/6YWSzkz3V" crossorigin="anonymous">
     <link rel="stylesheet" href="/<?= $this->assets('css/laminas.css') ?>">


### PR DESCRIPTION
Signed-off-by: Michael Bourquin <mbourquin@devprod.com>

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The goal of this PR is to **improve the positioning and visibility of laminas.org website** by adding some (basic) SEO enhancements for terms like PHP, framework, enterprise.

- Important terms like "PHP Framework" was missing in the meta title. I just propose to add it by default in each meta title.
- I also added the term "Enterprise", the final part of the meta title will be  **- Laminas Project - Enterprise PHP Framework**
- I also modified the main H1 in the home page to include principals terms, final H1 will be **Laminas Project, the enterprise-ready PHP Framework and components**, it is better than "It's Here!" 
- I also modified the buttons terms that target the documentation of Laminas, Mezzio and API Tools. This will transmit better keywords to each documentation domains than just "Learn more"
- Finally, i enabled the $enable-responsive-font-sizes option in bootstrap, because some fonts size (especially the title H1, H2) are too big on mobile device. (**I cannot test this last point on my machine because docker build do not work for me. Please test it**)

Of course **this terms can be adapted and discussed on your next Technical Steering Committee Meeting?**, it is just a proposition.
Something similar can be also applied to each documentation domains (with other terms of course)

I'm a PHP developer, user of Mezzio, ZF, Laminas,... and have also good skills with SEO, it is the reason i've created this PR.
