### PR TITLE
Removed unused `laminas/laminas-dependency-plugin`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
             "php": "8.0"
         },
         "allow-plugins": {
-            "laminas/laminas-dependency-plugin": true,
             "laminas/laminas-component-installer": true,
             "composer/package-versions-deprecated": true
         }
@@ -34,7 +33,6 @@
         "dflydev/fig-cookies": "^3.0",
         "laminas/laminas-component-installer": "^2.5",
         "laminas/laminas-config-aggregator": "^1.4",
-        "laminas/laminas-dependency-plugin": "^2.1",
         "laminas/laminas-diactoros": "^2.5.1",
         "laminas/laminas-feed": "^2.13.1",
         "laminas/laminas-paginator": "^2.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66ab3cd9b3b629e1bdb69b8fc21b207e",
+    "content-hash": "f8117383823bca73d88a398a3ac783c3",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -308,59 +308,6 @@
                 }
             ],
             "time": "2022-07-24T15:41:06+00:00"
-        },
-        {
-            "name": "laminas/laminas-dependency-plugin",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-dependency-plugin.git",
-                "reference": "73cfb63ddca9d6bfedad5e0a038f6d55063975a3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-dependency-plugin/zipball/73cfb63ddca9d6bfedad5e0a038f6d55063975a3",
-                "reference": "73cfb63ddca9d6bfedad5e0a038f6d55063975a3",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1 || ^2.0",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.9 || ^2.0",
-                "laminas/laminas-coding-standard": "^2.2.1",
-                "mikey179/vfsstream": "^1.6.10@alpha",
-                "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "roave/security-advisories": "dev-master",
-                "vimeo/psalm": "^4.5"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Laminas\\DependencyPlugin\\DependencyRewriterPluginDelegator"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\DependencyPlugin\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Replace zendframework and zfcampus packages with their Laminas Project equivalents.",
-            "support": {
-                "issues": "https://github.com/laminas/laminas-dependency-plugin/issues",
-                "source": "https://github.com/laminas/laminas-dependency-plugin/tree/2.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-08T17:51:35+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",


### PR DESCRIPTION
This plugin conflicts with latest `composer/composer` releases, and is not used inside
this repo as per https://github.com/laminas/getlaminas.org/pull/106#issuecomment-1207595866


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
