### PR TITLE
Adds missing container for grid with logos to prevent negative margins

### DIFF
--- a/templates/app/home-page.phtml
+++ b/templates/app/home-page.phtml
@@ -105,12 +105,14 @@
                 Laminas Projects are supported by these commercial vendors.
             </p>
 
-            <div class="row align-items-center justify-content-center">
-            <?php foreach ($commercialVendors as $commercialVendor): ?>
-                <div class="col-12 col-sm-6 col-md-4 col-lg-2">
-                    <img class="img-fluid" src="<?= $this->escapeHtmlAttr($commercialVendor['logo']) ?>" alt="<?= $this->escapeHtmlAttr($commercialVendor['name']) ?>">
+            <div class="container">
+                <div class="row align-items-center justify-content-center">
+                <?php foreach ($commercialVendors as $commercialVendor): ?>
+                    <div class="col-12 col-sm-6 col-md-4 col-lg-2">
+                        <img class="img-fluid" src="<?= $this->escapeHtmlAttr($commercialVendor['logo']) ?>" alt="<?= $this->escapeHtmlAttr($commercialVendor['name']) ?>">
+                    </div>
+                <?php endforeach ?>
                 </div>
-            <?php endforeach ?>
             </div>
 
             <div class="mt-4">


### PR DESCRIPTION
The rows come with negative margins:

![getlaminas org_](https://user-images.githubusercontent.com/103362/183885258-b685f0e0-6019-4514-be18-58268143d675.png)


https://getbootstrap.com/docs/4.6/layout/grid/#how-it-works