### PR TITLE
Add psalm to CI pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,9 @@
         "laminas/laminas-development-mode": "^3.3",
         "mezzio/mezzio-tooling": "^2.6",
         "phpunit/phpunit": "^9.5.12",
-        "roave/security-advisories": "dev-master"
+        "psalm/plugin-phpunit": "^0.16.0",
+        "roave/security-advisories": "dev-master",
+        "vimeo/psalm": "^4.7"
     },
     "replace": {
         "laminas/laminas-zendframework-bridge": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97411795f4ab9128167f83fea6049513",
+    "content-hash": "c1b23ecd5449813d42baab2b50cf609f",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -4014,6 +4014,463 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-20T17:52:18+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "reference": "b4f54f74ef3453349c24a845d22392cd31e65f1d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-17T14:14:24+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T20:21:48+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-01T19:23:25+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",
             "source": {
@@ -4089,6 +4546,43 @@
             "time": "2022-02-04T12:51:07+00:00"
         },
         {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.1",
             "source": {
@@ -4157,6 +4651,107 @@
                 }
             ],
             "time": "2022-03-03T08:28:38+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
+            },
+            "time": "2022-03-02T22:36:06+00:00"
         },
         {
             "name": "filp/whoops",
@@ -4548,6 +5143,110 @@
                 }
             ],
             "time": "2022-03-03T13:19:32+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
+            },
+            "time": "2020-12-01T19:48:11+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5351,6 +6050,66 @@
                 }
             ],
             "time": "2022-06-19T12:14:25+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "5dd3be04f37a857d52880ef6af2524a441dfef24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/5dd3be04f37a857d52880ef6af2524a441dfef24",
+                "reference": "5dd3be04f37a857d52880ef6af2524a441dfef24",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.16.1"
+            },
+            "time": "2021-06-18T23:56:46+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -7060,6 +7819,113 @@
             "time": "2021-07-28T10:34:58+00:00"
         },
         {
+            "name": "vimeo/psalm",
+            "version": "4.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "6998fabb2bf528b65777bf9941920888d23c03ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/6998fabb2bf528b65777bf9941920888d23c03ac",
+                "reference": "6998fabb2bf528b65777bf9941920888d23c03ac",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.13",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.25",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.16",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3 || ^5.0 || ^6.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ],
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.26.0"
+            },
+            "time": "2022-07-31T13:10:26+00:00"
+        },
+        {
             "name": "webimpress/coding-standard",
             "version": "1.2.4",
             "source": {
@@ -7113,6 +7979,57 @@
                 }
             ],
             "time": "2022-02-15T19:52:12+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "abandoned": "symfony/filesystem",
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],
@@ -7130,5 +8047,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.26.0@6998fabb2bf528b65777bf9941920888d23c03ac">
+  <file src="bin/clear-config-cache.php">
+    <MixedArgument occurrences="5">
+      <code>$config['config_cache_path']</code>
+      <code>$config['config_cache_path']</code>
+      <code>$config['config_cache_path']</code>
+      <code>$config['config_cache_path']</code>
+      <code>$config['config_cache_path']</code>
+    </MixedArgument>
+  </file>
+  <file src="config/container.php">
+    <MixedArgument occurrences="1">
+      <code>$dependencies</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$dependencies['services']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$dependencies['services']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="1">
+      <code>$dependencies</code>
+    </MixedAssignment>
+  </file>
+  <file src="config/pipeline.php">
+    <UnusedClosureParam occurrences="2">
+      <code>$container</code>
+      <code>$factory</code>
+    </UnusedClosureParam>
+  </file>
+  <file src="config/routes.php">
+    <UnusedClosureParam occurrences="2">
+      <code>$container</code>
+      <code>$factory</code>
+    </UnusedClosureParam>
+  </file>
+  <file src="public/index.php">
+    <MixedArgument occurrences="1">
+      <code>$factory</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$factory</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/App/AbstractCollection.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>[$this, 'order']</code>
+    </InvalidScalarArgument>
+    <MixedArgument occurrences="2">
+      <code>static::CACHE_FILE</code>
+      <code>static::CACHE_FILE</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>uasort($this-&gt;collection, [$this, 'order'])</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
+      <code>$this-&gt;collection</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>static::FOLDER_COLLECTION</code>
+    </MixedOperand>
+  </file>
+  <file src="src/App/FrontMatter/Document.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;document-&gt;matter()</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/App/Handler/StaticPageHandler.php">
+    <PossiblyFalseArgument occurrences="1">
+      <code>$routeResult-&gt;getMatchedRouteName()</code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="src/App/Template/InjectAssetRevisionsDelegator.php">
+    <MixedAssignment occurrences="1">
+      <code>$revisions</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Blog/BlogPost.php">
+    <MixedPropertyTypeCoercion occurrences="1">
+      <code>$tags</code>
+    </MixedPropertyTypeCoercion>
+  </file>
+  <file src="src/Blog/Console/FeedGenerator.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$latest-&gt;updated</code>
+    </ArgumentTypeCoercion>
+    <MixedArgument occurrences="1">
+      <code>$baseUri</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$baseUri</code>
+      <code>$outputDir</code>
+      <code>$post</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$outputDir</code>
+    </MixedOperand>
+    <UnusedParam occurrences="1">
+      <code>$post</code>
+    </UnusedParam>
+  </file>
+  <file src="src/Blog/Console/GenerateSearchData.php">
+    <MixedArgument occurrences="1">
+      <code>$basePath</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$basePath</code>
+      <code>$fileInfo</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Blog/Console/RoutesTrait.php">
+    <UndefinedFunction occurrences="1">
+      <code>RuntimeException('This should never be called')</code>
+    </UndefinedFunction>
+  </file>
+  <file src="src/Blog/Console/SeedBlogDatabase.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>(new DateTimeImmutable('now'))-&gt;getTimestamp()</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="3">
+      <code>$basePath</code>
+      <code>$dbPath</code>
+      <code>$postsPath</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="5">
+      <code>$basePath</code>
+      <code>$dbPath</code>
+      <code>$fileInfo</code>
+      <code>$postsPath</code>
+      <code>$this-&gt;authorDataRootPath</code>
+    </MixedAssignment>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$post-&gt;created</code>
+      <code>$post-&gt;created</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Blog/CreateBlogPostFromDataArray.php">
+    <MixedArgument occurrences="9">
+      <code>$metadata['email'] ?? ''</code>
+      <code>$metadata['name'] ?? 'no-reply@getlaminas.org'</code>
+      <code>$metadata['uri'] ?? ''</code>
+      <code>$post['author']</code>
+      <code>$post['created']</code>
+      <code>$post['id']</code>
+      <code>$post['path']</code>
+      <code>$post['title']</code>
+      <code>$post['updated']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="3">
+      <code>$metadata['email']</code>
+      <code>$metadata['name']</code>
+      <code>$metadata['uri']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$metadata</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Blog/Handler/DisplayPostHandler.php">
+    <MixedArgument occurrences="1">
+      <code>$id</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$id</code>
+    </MixedAssignment>
+    <UnnecessaryVarAnnotation occurrences="2">
+      <code>?BlogPost</code>
+      <code>DateTimeInterface</code>
+    </UnnecessaryVarAnnotation>
+  </file>
+  <file src="src/Blog/Handler/FeedHandler.php">
+    <MixedArgument occurrences="3">
+      <code>$tag</code>
+      <code>$type</code>
+      <code>$type</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$tag</code>
+      <code>$type</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Blog/Handler/ListPostsHandler.php">
+    <MixedArgument occurrences="4">
+      <code>$path</code>
+      <code>$path</code>
+      <code>$posts-&gt;getItemsByPage($page)</code>
+      <code>$request-&gt;getAttribute('tag', '')</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$page</code>
+      <code>$path</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>getPath</code>
+      <code>getUri</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/Blog/Handler/SearchHandler.php">
+    <MethodSignatureMustOmitReturnType occurrences="1">
+      <code>public function __construct(</code>
+    </MethodSignatureMustOmitReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;mapper-&gt;search($toMatch)</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Blog/Mapper/MapperFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$config['db'] ?? ''</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Blog/Mapper/PdoMapper.php">
+    <MixedArgument occurrences="1">
+      <code>$post</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$params</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
+      <code>$post</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Blog/Mapper/PdoPaginator.php">
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>BlogPost[]</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/Blog/PlatesFunctionsDelegator.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;template-&gt;url('blog.post', ['id' =&gt; $post-&gt;id])</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/ReleaseFeed/ReceiveFeedItemHandler.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$latest</code>
+      <code>$latest</code>
+    </ArgumentTypeCoercion>
+    <MixedArgument occurrences="16">
+      <code>$authorName</code>
+      <code>$authorName</code>
+      <code>$authorUrl</code>
+      <code>$authorUrl</code>
+      <code>$data['author_name']</code>
+      <code>$data['author_url']</code>
+      <code>$data['author_url']</code>
+      <code>$data['changelog']</code>
+      <code>$data['package']</code>
+      <code>$data['publication_date']</code>
+      <code>$data['url']</code>
+      <code>$data['version']</code>
+      <code>$date</code>
+      <code>$entry-&gt;getContent()</code>
+      <code>$entry-&gt;getLink()</code>
+      <code>$title</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="2">
+      <code>$author['name']</code>
+      <code>$author['uri']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="7">
+      <code>$author</code>
+      <code>$authorName</code>
+      <code>$authorUrl</code>
+      <code>$authorUrl</code>
+      <code>$date</code>
+      <code>$entry</code>
+      <code>$title</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="5">
+      <code>getAuthor</code>
+      <code>getContent</code>
+      <code>getDateCreated</code>
+      <code>getLink</code>
+      <code>getTitle</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$data</code>
+      <code>$data</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/Security/Handler/AdvisoryHandler.php">
+    <MixedArgument occurrences="1">
+      <code>$advisory</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$advisory</code>
+      <code>$content['advisory']</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Security/Handler/SecurityHandler.php">
+    <MixedArgument occurrences="6">
+      <code>$action</code>
+      <code>$content['body'] ?? ''</code>
+      <code>$content['date'] ?? 'now'</code>
+      <code>$content['date'] ?? 'now'</code>
+      <code>$content['title'] ?? ''</code>
+      <code>$first['date']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$first['date']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$action</code>
+      <code>$first</code>
+    </MixedAssignment>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -166,10 +166,6 @@
     <MixedAssignment occurrences="1">
       <code>$id</code>
     </MixedAssignment>
-    <UnnecessaryVarAnnotation occurrences="2">
-      <code>?BlogPost</code>
-      <code>DateTimeInterface</code>
-    </UnnecessaryVarAnnotation>
   </file>
   <file src="src/Blog/Handler/FeedHandler.php">
     <MixedArgument occurrences="3">
@@ -189,6 +185,9 @@
       <code>$posts-&gt;getItemsByPage($page)</code>
       <code>$request-&gt;getAttribute('tag', '')</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>iterator_to_array($posts-&gt;getItemsByPage($page))</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="2">
       <code>$page</code>
       <code>$path</code>
@@ -199,9 +198,6 @@
     </MixedMethodCall>
   </file>
   <file src="src/Blog/Handler/SearchHandler.php">
-    <MethodSignatureMustOmitReturnType occurrences="1">
-      <code>public function __construct(</code>
-    </MethodSignatureMustOmitReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;mapper-&gt;search($toMatch)</code>
     </PossiblyNullArgument>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="bin"/>
+        <directory name="config"/>
+        <directory name="src"/>
+        <directory name="templates"/>
+        <directory name="test"/>
+        <file name="public/index.php"/>
+        <ignoreFiles>
+            <directory name="bootstrap"/>
+            <directory name="data"/>
+            <directory name="var"/>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -13,12 +13,6 @@
         <directory name="templates"/>
         <directory name="test"/>
         <file name="public/index.php"/>
-        <ignoreFiles>
-            <directory name="bootstrap"/>
-            <directory name="data"/>
-            <directory name="var"/>
-            <directory name="vendor"/>
-        </ignoreFiles>
     </projectFiles>
 
     <issueHandlers>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="bin"/>

--- a/src/App/AbstractCollection.php
+++ b/src/App/AbstractCollection.php
@@ -17,7 +17,10 @@ use const LOCK_EX;
 
 abstract class AbstractCollection
 {
+    /** @var string */
     protected const FOLDER_COLLECTION = '';
+
+    /** @var string */
     protected const CACHE_FILE        = '';
 
     protected array $collection = [];

--- a/src/App/AbstractCollection.php
+++ b/src/App/AbstractCollection.php
@@ -21,7 +21,7 @@ abstract class AbstractCollection
     protected const FOLDER_COLLECTION = '';
 
     /** @var string */
-    protected const CACHE_FILE        = '';
+    protected const CACHE_FILE = '';
 
     protected array $collection = [];
 

--- a/src/App/AccessLoggerFactory.php
+++ b/src/App/AccessLoggerFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App;
 
 use Monolog\Handler\StreamHandler;
+use Monolog\Level;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\LoggerInterface;
@@ -16,7 +17,7 @@ class AccessLoggerFactory
         $logger = new Logger('getlaminas');
         $logger->pushHandler(new StreamHandler(
             stream: 'php://stderr',
-            level: Logger::INFO,
+            level: Level::Debug,
             bubble: true,
         ));
         $logger->pushProcessor(new PsrLogMessageProcessor());

--- a/src/App/EventDispatcherFactory.php
+++ b/src/App/EventDispatcherFactory.php
@@ -13,8 +13,9 @@ class EventDispatcherFactory
 {
     public function __invoke(ContainerInterface $container): EventDispatcherInterface
     {
-        return new EventDispatcher(
-            $container->get(ListenerProviderInterface::class)
-        );
+        $provider = $container->get(ListenerProviderInterface::class);
+        assert($provider instanceof ListenerProviderInterface);
+
+        return new EventDispatcher($provider);
     }
 }

--- a/src/App/EventDispatcherFactory.php
+++ b/src/App/EventDispatcherFactory.php
@@ -9,6 +9,8 @@ use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 
+use function assert;
+
 class EventDispatcherFactory
 {
     public function __invoke(ContainerInterface $container): EventDispatcherInterface

--- a/src/App/FrontMatter/Document.php
+++ b/src/App/FrontMatter/Document.php
@@ -39,7 +39,7 @@ final class Document implements DocumentInterface
         $converter = new MarkdownConverter($env);
 
         return $this->postProcessHtml(
-            $converter->convertToHtml($this->document->body())->getContent()
+            $converter->convert($this->document->body())->getContent()
         );
     }
 

--- a/src/App/Handler/CommercialVendorsHandlerFactory.php
+++ b/src/App/Handler/CommercialVendorsHandlerFactory.php
@@ -7,6 +7,9 @@ namespace App\Handler;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+use function is_array;
+
 class CommercialVendorsHandlerFactory
 {
     public function __invoke(ContainerInterface $container): CommercialVendorsHandler

--- a/src/App/Handler/CommercialVendorsHandlerFactory.php
+++ b/src/App/Handler/CommercialVendorsHandlerFactory.php
@@ -11,9 +11,12 @@ class CommercialVendorsHandlerFactory
 {
     public function __invoke(ContainerInterface $container): CommercialVendorsHandler
     {
-        return new CommercialVendorsHandler(
-            $container->get('config')['commercial-vendors'],
-            $container->get(TemplateRendererInterface::class)
-        );
+        $commercialVendors = $container->get('config')['commercial-vendors'] ?? [];
+        assert(is_array($commercialVendors));
+
+        $renderer = $container->get(TemplateRendererInterface::class);
+        assert($renderer instanceof TemplateRendererInterface);
+
+        return new CommercialVendorsHandler($commercialVendors, $renderer);
     }
 }

--- a/src/App/Handler/HomePageHandlerFactory.php
+++ b/src/App/Handler/HomePageHandlerFactory.php
@@ -11,9 +11,12 @@ class HomePageHandlerFactory
 {
     public function __invoke(ContainerInterface $container): HomePageHandler
     {
-        return new HomePageHandler(
-            $container->get('config')['commercial-vendors'],
-            $container->get(TemplateRendererInterface::class)
-        );
+        $commercialVendors = $container->get('config')['commercial-vendors'] ?? [];
+        assert(is_array($commercialVendors));
+
+        $renderer = $container->get(TemplateRendererInterface::class);
+        assert($renderer instanceof TemplateRendererInterface);
+
+        return new HomePageHandler($commercialVendors, $renderer);
     }
 }

--- a/src/App/Handler/HomePageHandlerFactory.php
+++ b/src/App/Handler/HomePageHandlerFactory.php
@@ -7,6 +7,9 @@ namespace App\Handler;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+use function is_array;
+
 class HomePageHandlerFactory
 {
     public function __invoke(ContainerInterface $container): HomePageHandler

--- a/src/App/Handler/StaticPageHandlerFactory.php
+++ b/src/App/Handler/StaticPageHandlerFactory.php
@@ -11,6 +11,9 @@ class StaticPageHandlerFactory
 {
     public function __invoke(ContainerInterface $container): StaticPageHandler
     {
-        return new StaticPageHandler($container->get(TemplateRendererInterface::class));
+        $renderer = $container->get(TemplateRendererInterface::class);
+        assert($renderer instanceof TemplateRendererInterface);
+
+        return new StaticPageHandler($renderer);
     }
 }

--- a/src/App/Handler/StaticPageHandlerFactory.php
+++ b/src/App/Handler/StaticPageHandlerFactory.php
@@ -7,6 +7,8 @@ namespace App\Handler;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class StaticPageHandlerFactory
 {
     public function __invoke(ContainerInterface $container): StaticPageHandler

--- a/src/App/LoggingErrorListenerDelegator.php
+++ b/src/App/LoggingErrorListenerDelegator.php
@@ -8,6 +8,8 @@ use Laminas\Stratigility\Middleware\ErrorHandler;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
+use function assert;
+
 class LoggingErrorListenerDelegator
 {
     public function __invoke(

--- a/src/App/LoggingErrorListenerDelegator.php
+++ b/src/App/LoggingErrorListenerDelegator.php
@@ -16,9 +16,13 @@ class LoggingErrorListenerDelegator
         callable $callback
     ): ErrorHandler {
         $errorHandler = $callback();
-        $errorHandler->attachListener(
-            new LoggingErrorListener($container->get(LoggerInterface::class))
-        );
+        assert($errorHandler instanceof ErrorHandler);
+
+        $logger = $container->get(LoggerInterface::class);
+        assert($logger instanceof LoggerInterface);
+
+        $errorHandler->attachListener(new LoggingErrorListener($logger));
+
         return $errorHandler;
     }
 }

--- a/src/App/Template/InjectAssetRevisionsDelegator.php
+++ b/src/App/Template/InjectAssetRevisionsDelegator.php
@@ -8,6 +8,7 @@ use Closure;
 use League\Plates\Engine as PlatesEngine;
 use Psr\Container\ContainerInterface;
 
+use function assert;
 use function file_exists;
 use function file_get_contents;
 use function getcwd;
@@ -18,7 +19,7 @@ class InjectAssetRevisionsDelegator
 {
     public function __invoke(ContainerInterface $container, string $serviceName, callable $factory): PlatesEngine
     {
-        $engine    = $factory();
+        $engine = $factory();
         assert($engine instanceof PlatesEngine);
 
         $config = $container->get('config') ?? [];

--- a/src/App/Template/InjectAssetRevisionsDelegator.php
+++ b/src/App/Template/InjectAssetRevisionsDelegator.php
@@ -19,8 +19,13 @@ class InjectAssetRevisionsDelegator
     public function __invoke(ContainerInterface $container, string $serviceName, callable $factory): PlatesEngine
     {
         $engine    = $factory();
-        $config    = $container->get('config');
+        assert($engine instanceof PlatesEngine);
+
+        $config = $container->get('config') ?? [];
+        assert(is_array($config));
+
         $revisions = $config['asset-revisions'] ?? [];
+        assert(is_array($revisions));
 
         isset($config['debug'])
             ? $this->injectAssets($engine, Closure::fromCallable([$this, 'getAssetMap']))
@@ -33,8 +38,10 @@ class InjectAssetRevisionsDelegator
 
     private function injectAssets(PlatesEngine $engine, callable $getAssetMap): void
     {
-        $engine->registerFunction('assets', function ($asset) use ($getAssetMap) {
+        $engine->registerFunction('assets', function (string $asset) use ($getAssetMap) {
             $assetMap = $getAssetMap();
+            assert(is_array($assetMap));
+
             return $assetMap[$asset] ?? $asset;
         });
     }

--- a/src/Blog/ConfigProvider.php
+++ b/src/Blog/ConfigProvider.php
@@ -36,7 +36,6 @@ class ConfigProvider
             'factories' => [
                 'config-blog'                                   => ConfigFactory::class,
                 Console\FeedGenerator::class                    => Console\FeedGeneratorFactory::class,
-                Console\TagCloud::class                         => Console\TagCloudFactory::class,
                 Handler\DisplayPostHandler::class               => Handler\DisplayPostHandlerFactory::class,
                 Handler\FeedHandler::class                      => Handler\FeedHandlerFactory::class,
                 Handler\ListPostsHandler::class                 => Handler\ListPostsHandlerFactory::class,

--- a/src/Blog/Console/FeedGenerator.php
+++ b/src/Blog/Console/FeedGenerator.php
@@ -143,6 +143,7 @@ class FeedGenerator extends Command
         }
 
         foreach ($posts as $post) {
+            /** @var BlogPost $post */
             $html   = $post->body . $post->extended;
             $author = $this->getAuthor($post->author);
 
@@ -164,7 +165,9 @@ class FeedGenerator extends Command
         }
 
         // Set feed date
-        $feed->setDateModified($latest->updated);
+        if ($latest instanceof BlogPost) {
+            $feed->setDateModified($latest->updated);
+        }
 
         // Write feed to file
         $file = sprintf('%s%s.xml', $fileBase, $type);

--- a/src/Blog/Console/FeedGenerator.php
+++ b/src/Blog/Console/FeedGenerator.php
@@ -106,7 +106,7 @@ class FeedGenerator extends Command
         string $feedRoute,
         array $routeOptions,
         Traversable $posts
-    ) {
+    ): void {
         foreach (['atom', 'rss'] as $type) {
             $this->generateFeed($type, $fileBase, $baseUri, $title, $landingRoute, $feedRoute, $routeOptions, $posts);
         }
@@ -121,7 +121,7 @@ class FeedGenerator extends Command
         string $feedRoute,
         array $routeOptions,
         Traversable $posts
-    ) {
+    ): void {
         $routeOptions['type'] = $type;
 
         $landingUri = $baseUri . $this->generateUri($landingRoute, $routeOptions);

--- a/src/Blog/Console/FeedGeneratorFactory.php
+++ b/src/Blog/Console/FeedGeneratorFactory.php
@@ -17,11 +17,23 @@ class FeedGeneratorFactory
 {
     public function __invoke(ContainerInterface $container): FeedGenerator
     {
+        $mapper = $container->get(MapperInterface::class);
+        assert($mapper instanceof MapperInterface);
+
+        $router = $container->get(RouterInterface::class);
+        assert($router instanceof RouterInterface);
+
+        $renderer = $container->get(TemplateRendererInterface::class);
+        assert($renderer instanceof TemplateRendererInterface);
+
+        $serverUrlHelper = $container->get(ServerUrlHelper::class);
+        assert($serverUrlHelper instanceof ServerUrlHelper);
+
         return new FeedGenerator(
-            $container->get(MapperInterface::class),
-            $container->get(RouterInterface::class),
-            $container->get(TemplateRendererInterface::class),
-            $container->get(ServerUrlHelper::class),
+            $mapper,
+            $router,
+            $renderer,
+            $serverUrlHelper,
             realpath(getcwd()) . '/data/blog/authors/'
         );
     }

--- a/src/Blog/Console/FeedGeneratorFactory.php
+++ b/src/Blog/Console/FeedGeneratorFactory.php
@@ -10,6 +10,7 @@ use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
 use function getcwd;
 use function realpath;
 

--- a/src/Blog/Console/GenerateSearchData.php
+++ b/src/Blog/Console/GenerateSearchData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GetLaminas\Blog\Console;
 
 use GetLaminas\Blog\CreateBlogPostFromDataArray;
+use SplFileInfo;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -52,6 +53,7 @@ class GenerateSearchData extends Command
 
         $documents = [];
         foreach (new MarkdownFileFilter($path) as $fileInfo) {
+            /** @var SplFileInfo $fileInfo */
             $post        = $this->createBlogPostFromDataArray(['path' => $fileInfo->getPathname()]);
             $documents[] = [
                 'id'      => sprintf('/blog/%s.html', $post->id),

--- a/src/Blog/Console/MarkdownFileFilter.php
+++ b/src/Blog/Console/MarkdownFileFilter.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace GetLaminas\Blog\Console;
 
-use DirectoryIterator;
 use FilterIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
-use RecursiveIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
 use function is_dir;
-use function is_string;
 use function sprintf;
 
 /**

--- a/src/Blog/Console/MarkdownFileFilter.php
+++ b/src/Blog/Console/MarkdownFileFilter.php
@@ -35,25 +35,18 @@ class MarkdownFileFilter extends FilterIterator
 {
     public function __construct(string $dirOrIterator = '.')
     {
-        if (is_string($dirOrIterator)) {
-            if (! is_dir($dirOrIterator)) {
-                throw new InvalidArgumentException(sprintf(
-                    'Expected a valid directory name; received "%s"',
-                    $dirOrIterator
-                ));
-            }
-
-            $dirOrIterator = new RecursiveDirectoryIterator($dirOrIterator);
-        }
-        if (! $dirOrIterator instanceof DirectoryIterator) {
-            throw new InvalidArgumentException('Expected a DirectoryIterator');
+        if (! is_dir($dirOrIterator)) {
+            throw new InvalidArgumentException(sprintf(
+                'Expected a valid directory name; received "%s"',
+                $dirOrIterator
+            ));
         }
 
-        $iterator = $dirOrIterator instanceof RecursiveIterator
-            ? new RecursiveIteratorIterator($dirOrIterator)
-            : $dirOrIterator;
+        $dirOrIterator = new RecursiveDirectoryIterator($dirOrIterator);
+        $iterator      = new RecursiveIteratorIterator($dirOrIterator);
 
         parent::__construct($iterator);
+
         $this->rewind();
     }
 

--- a/src/Blog/Console/RoutesTrait.php
+++ b/src/Blog/Console/RoutesTrait.php
@@ -10,7 +10,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use RuntimeException;
 
 trait RoutesTrait
 {

--- a/src/Blog/Console/RoutesTrait.php
+++ b/src/Blog/Console/RoutesTrait.php
@@ -10,9 +10,11 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 
 trait RoutesTrait
 {
+    /** @var array<string, string> */
     private array $routes = [
         'blog'               => '/blog[/]',
         'blog.post'          => '/blog/{id:[^/]+}.html',
@@ -33,6 +35,7 @@ trait RoutesTrait
                 ServerRequestInterface $request,
                 RequestHandlerInterface $handler
             ): ResponseInterface {
+                throw RuntimeException('This should never be called');
             }
         };
 

--- a/src/Blog/CreateBlogPostFromDataArray.php
+++ b/src/Blog/CreateBlogPostFromDataArray.php
@@ -21,18 +21,14 @@ use function trim;
 
 trait CreateBlogPostFromDataArray
 {
-    /** @var string */
-    private $authorDataRootPath = 'data/blog/authors';
+    private string $authorDataRootPath = 'data/blog/authors';
 
-    /** @var ParserInterface */
-    private $frontMatterParser;
+    private ?ParserInterface $frontMatterParser = null;
 
     /**
      * Delimiter between post summary and extended body
-     *
-     * @var string
      */
-    private $postDelimiter = '<!--- EXTENDED -->';
+    private string $postDelimiter = '<!--- EXTENDED -->';
 
     public function setAuthorDataRootPath(string $path): void
     {
@@ -41,7 +37,7 @@ trait CreateBlogPostFromDataArray
 
     private function getFrontMatterParser(): ParserInterface
     {
-        if (! $this->frontMatterParser) {
+        if (null === $this->frontMatterParser) {
             $this->frontMatterParser = new Parser();
         }
 

--- a/src/Blog/Handler/DisplayPostHandler.php
+++ b/src/Blog/Handler/DisplayPostHandler.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace GetLaminas\Blog\Handler;
 
-use DateTimeInterface;
-use GetLaminas\Blog\BlogPost;
 use GetLaminas\Blog\FetchBlogPostEvent;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Template\TemplateRendererInterface;
@@ -34,14 +32,12 @@ class DisplayPostHandler implements RequestHandlerInterface
         /** @var FetchBlogPostEvent $event */
         $event = $this->dispatcher->dispatch(new FetchBlogPostEvent($id));
 
-        /** @var ?BlogPost $post */
         $post = $event->blogPost();
 
         if (! $post) {
             return $this->notFoundHandler->handle($request);
         }
 
-        /** @var DateTimeInterface $lastModified */
         $lastModified = $post->updated ?: $post->created;
 
         return new HtmlResponse(

--- a/src/Blog/Handler/DisplayPostHandlerFactory.php
+++ b/src/Blog/Handler/DisplayPostHandlerFactory.php
@@ -9,6 +9,8 @@ use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 
+use function assert;
+
 class DisplayPostHandlerFactory
 {
     public function __invoke(ContainerInterface $container): DisplayPostHandler

--- a/src/Blog/Handler/DisplayPostHandlerFactory.php
+++ b/src/Blog/Handler/DisplayPostHandlerFactory.php
@@ -13,10 +13,15 @@ class DisplayPostHandlerFactory
 {
     public function __invoke(ContainerInterface $container): DisplayPostHandler
     {
-        return new DisplayPostHandler(
-            $container->get(EventDispatcherInterface::class),
-            $container->get(TemplateRendererInterface::class),
-            $container->get(NotFoundHandler::class)
-        );
+        $dispatcher = $container->get(EventDispatcherInterface::class);
+        assert($dispatcher instanceof EventDispatcherInterface);
+
+        $renderer = $container->get(TemplateRendererInterface::class);
+        assert($renderer instanceof TemplateRendererInterface);
+
+        $notFoundHandler = $container->get(NotFoundHandler::class);
+        assert($notFoundHandler instanceof NotFoundHandler);
+
+        return new DisplayPostHandler($dispatcher, $renderer, $notFoundHandler);
     }
 }

--- a/src/Blog/Handler/FeedHandlerFactory.php
+++ b/src/Blog/Handler/FeedHandlerFactory.php
@@ -7,6 +7,8 @@ namespace GetLaminas\Blog\Handler;
 use Mezzio\Handler\NotFoundHandler;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class FeedHandlerFactory
 {
     public function __invoke(ContainerInterface $container): FeedHandler

--- a/src/Blog/Handler/FeedHandlerFactory.php
+++ b/src/Blog/Handler/FeedHandlerFactory.php
@@ -11,8 +11,9 @@ class FeedHandlerFactory
 {
     public function __invoke(ContainerInterface $container): FeedHandler
     {
-        return new FeedHandler(
-            $container->get(NotFoundHandler::class)
-        );
+        $notFoundHandler = $container->get(NotFoundHandler::class);
+        assert($notFoundHandler instanceof NotFoundHandler);
+
+        return new FeedHandler($notFoundHandler);
     }
 }

--- a/src/Blog/Handler/ListPostsHandler.php
+++ b/src/Blog/Handler/ListPostsHandler.php
@@ -74,12 +74,6 @@ class ListPostsHandler implements RequestHandlerInterface
         return $page < 1 ? 1 : $page;
     }
 
-    /**
-     * @var string $path
-     * @var int $page
-     * @var object $pagination
-     * @return object $pagination
-     */
     private function preparePagination(string $path, int $page, stdClass $pagination): stdClass
     {
         $pagination->base_path = $path;
@@ -99,11 +93,7 @@ class ListPostsHandler implements RequestHandlerInterface
         return $pagination;
     }
 
-    /**
-     * @param BlogPost[] $entries
-     * @param object $pagination
-     * @return array
-     */
+    /** @param BlogPost[] $entries */
     private function prepareView(string $tag, array $entries, stdClass $pagination): array
     {
         $view = $tag ? ['tag' => $tag] : [];

--- a/src/Blog/Handler/ListPostsHandler.php
+++ b/src/Blog/Handler/ListPostsHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GetLaminas\Blog\Handler;
 
+use GetLaminas\Blog\BlogPost;
 use GetLaminas\Blog\Mapper\MapperInterface;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Laminas\Diactoros\Response\RedirectResponse;
@@ -81,7 +82,7 @@ class ListPostsHandler implements RequestHandlerInterface
         $pagination->is_last   = $page === $pagination->last;
 
         $pages = [];
-        for ($i = $pagination->firstPageInRange; $i <= $pagination->lastPageInRange; $i += 1) {
+        for ($i = (int) $pagination->firstPageInRange; $i <= (int) $pagination->lastPageInRange; $i += 1) {
             $pages[] = [
                 'base_path' => $path,
                 'number'    => $i,
@@ -93,7 +94,7 @@ class ListPostsHandler implements RequestHandlerInterface
         return $pagination;
     }
 
-    /** @param BlogPost[] $entries */
+    /** @param BlogPost[] entries */
     private function prepareView(string $tag, array $entries, stdClass $pagination): array
     {
         $view = $tag ? ['tag' => $tag] : [];
@@ -102,9 +103,9 @@ class ListPostsHandler implements RequestHandlerInterface
             $view['rss']  = $this->router->generateUri('blog.tag.feed', ['tag' => $tag, 'type' => 'rss']);
         }
 
-        return array_merge($view, [
+        return [...$view, ...[
             'posts'      => $entries,
             'pagination' => $pagination,
-        ]);
+        ]];
     }
 }

--- a/src/Blog/Handler/ListPostsHandler.php
+++ b/src/Blog/Handler/ListPostsHandler.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use stdClass;
 
-use function array_merge;
 use function count;
 use function iterator_to_array;
 use function sprintf;
@@ -94,7 +93,10 @@ class ListPostsHandler implements RequestHandlerInterface
         return $pagination;
     }
 
-    /** @param BlogPost[] entries */
+    /**
+     * @param BlogPost[] $entries
+     * @psalm-return array<string, mixed>
+     */
     private function prepareView(string $tag, array $entries, stdClass $pagination): array
     {
         $view = $tag ? ['tag' => $tag] : [];
@@ -103,9 +105,12 @@ class ListPostsHandler implements RequestHandlerInterface
             $view['rss']  = $this->router->generateUri('blog.tag.feed', ['tag' => $tag, 'type' => 'rss']);
         }
 
-        return [...$view, ...[
-            'posts'      => $entries,
-            'pagination' => $pagination,
-        ]];
+        return [
+            ...$view,
+            ...[
+                'posts'      => $entries,
+                'pagination' => $pagination,
+            ],
+        ];
     }
 }

--- a/src/Blog/Handler/ListPostsHandlerFactory.php
+++ b/src/Blog/Handler/ListPostsHandlerFactory.php
@@ -9,6 +9,8 @@ use Mezzio\Router\RouterInterface;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class ListPostsHandlerFactory
 {
     public function __invoke(ContainerInterface $container): ListPostsHandler

--- a/src/Blog/Handler/ListPostsHandlerFactory.php
+++ b/src/Blog/Handler/ListPostsHandlerFactory.php
@@ -13,10 +13,15 @@ class ListPostsHandlerFactory
 {
     public function __invoke(ContainerInterface $container): ListPostsHandler
     {
-        return new ListPostsHandler(
-            $container->get(MapperInterface::class),
-            $container->get(TemplateRendererInterface::class),
-            $container->get(RouterInterface::class)
-        );
+        $mapper = $container->get(MapperInterface::class);
+        assert($mapper instanceof MapperInterface);
+
+        $renderer = $container->get(TemplateRendererInterface::class);
+        assert($renderer instanceof TemplateRendererInterface);
+
+        $router = $container->get(RouterInterface::class);
+        assert($router instanceof RouterInterface);
+
+        return new ListPostsHandler($mapper, $renderer, $router);
     }
 }

--- a/src/Blog/Handler/SearchHandler.php
+++ b/src/Blog/Handler/SearchHandler.php
@@ -12,13 +12,14 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 use function array_map;
+use function is_string;
 
 class SearchHandler implements RequestHandlerInterface
 {
     public function __construct(
         private MapperInterface $mapper,
         private UrlHelper $urlHelper,
-    ): void {
+    ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface

--- a/src/Blog/Handler/SearchHandler.php
+++ b/src/Blog/Handler/SearchHandler.php
@@ -15,30 +15,21 @@ use function array_map;
 
 class SearchHandler implements RequestHandlerInterface
 {
-    /** @var MapperInterface */
-    private $mapper;
-
-    /** @var UrlHelper */
-    private $urlHelper;
-
-    public function __construct(MapperInterface $mapper, UrlHelper $urlHelper)
-    {
-        $this->mapper    = $mapper;
-        $this->urlHelper = $urlHelper;
+    public function __construct(
+        private MapperInterface $mapper,
+        private UrlHelper $urlHelper,
+    ): void {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $toMatch = $request->getQueryParams()['q'] ?? '';
 
-        if ('' === $toMatch) {
+        if (! is_string($toMatch) || '' === $toMatch) {
             return new JsonResponse([]);
         }
 
-        $results = array_map(function ($row) {
+        $results = array_map(function (array $row): array {
             return [
                 'link'  => $this->urlHelper->generate('blog.post', ['id' => $row['id']]),
                 'title' => $row['title'],

--- a/src/Blog/Handler/SearchHandlerFactory.php
+++ b/src/Blog/Handler/SearchHandlerFactory.php
@@ -12,9 +12,12 @@ class SearchHandlerFactory
 {
     public function __invoke(ContainerInterface $container): SearchHandler
     {
-        return new SearchHandler(
-            $container->get(MapperInterface::class),
-            $container->get(UrlHelper::class)
-        );
+        $mapper = $container->get(MapperInterface::class);
+        assert($mapper instanceof MapperInterface);
+
+        $urlHelper = $container->get(UrlHelper::class);
+        assert($urlHelper instanceof UrlHelper);
+
+        return new SearchHandler($mapper, $urlHelper);
     }
 }

--- a/src/Blog/Handler/SearchHandlerFactory.php
+++ b/src/Blog/Handler/SearchHandlerFactory.php
@@ -8,6 +8,8 @@ use GetLaminas\Blog\Mapper\MapperInterface;
 use Mezzio\Helper\UrlHelper;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class SearchHandlerFactory
 {
     public function __invoke(ContainerInterface $container): SearchHandler

--- a/src/Blog/Listener/FetchBlogPostEventListenersDelegator.php
+++ b/src/Blog/Listener/FetchBlogPostEventListenersDelegator.php
@@ -15,8 +15,13 @@ class FetchBlogPostEventListenersDelegator
         string $serviceName,
         callable $factory
     ): AttachableListenerProvider {
+        /** @var AttachableListenerProvider $provider */
         $provider = $factory();
-        $provider->listen(FetchBlogPostEvent::class, $container->get(FetchBlogPostFromMapperListener::class));
+
+        $listener = $container->get(FetchBlogPostFromMapperListener::class);
+        assert($listener instanceof FetchBlogPostFromMapperListener);
+
+        $provider->listen(FetchBlogPostEvent::class, $listener);
         return $provider;
     }
 }

--- a/src/Blog/Listener/FetchBlogPostEventListenersDelegator.php
+++ b/src/Blog/Listener/FetchBlogPostEventListenersDelegator.php
@@ -8,6 +8,8 @@ use GetLaminas\Blog\FetchBlogPostEvent;
 use Phly\EventDispatcher\ListenerProvider\AttachableListenerProvider;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class FetchBlogPostEventListenersDelegator
 {
     public function __invoke(

--- a/src/Blog/Listener/FetchBlogPostFromMapperListenerFactory.php
+++ b/src/Blog/Listener/FetchBlogPostFromMapperListenerFactory.php
@@ -7,6 +7,8 @@ namespace GetLaminas\Blog\Listener;
 use GetLaminas\Blog\Mapper\MapperInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class FetchBlogPostFromMapperListenerFactory
 {
     public function __invoke(ContainerInterface $container): FetchBlogPostFromMapperListener

--- a/src/Blog/Listener/FetchBlogPostFromMapperListenerFactory.php
+++ b/src/Blog/Listener/FetchBlogPostFromMapperListenerFactory.php
@@ -11,8 +11,9 @@ class FetchBlogPostFromMapperListenerFactory
 {
     public function __invoke(ContainerInterface $container): FetchBlogPostFromMapperListener
     {
-        return new FetchBlogPostFromMapperListener(
-            $container->get(MapperInterface::class)
-        );
+        $mapper = $container->get(MapperInterface::class);
+        assert($mapper instanceof MapperInterface);
+
+        return new FetchBlogPostFromMapperListener($mapper);
     }
 }

--- a/src/Blog/Mapper/MapperFactory.php
+++ b/src/Blog/Mapper/MapperFactory.php
@@ -7,6 +7,9 @@ namespace GetLaminas\Blog\Mapper;
 use PDO;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+use function is_array;
+
 class MapperFactory
 {
     public function __invoke(ContainerInterface $container): PdoMapper

--- a/src/Blog/Mapper/MapperFactory.php
+++ b/src/Blog/Mapper/MapperFactory.php
@@ -11,9 +11,12 @@ class MapperFactory
 {
     public function __invoke(ContainerInterface $container): PdoMapper
     {
-        $config = $container->get('config-blog');
-        $pdo    = new PDO($config['db'] ?? '');
+        $config = $container->get('config-blog') ?? [];
+        assert(is_array($config));
+
+        $pdo = new PDO($config['db'] ?? '');
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
         return new PdoMapper($pdo);
     }
 }

--- a/src/Blog/Mapper/MapperInterface.php
+++ b/src/Blog/Mapper/MapperInterface.php
@@ -9,9 +9,6 @@ use Laminas\Paginator\Paginator;
 
 interface MapperInterface
 {
-    /**
-     * @return false|array
-     */
     public function fetch(string $id): ?BlogPost;
 
     public function fetchAll(): Paginator;
@@ -20,5 +17,5 @@ interface MapperInterface
 
     public function fetchAllByTag(string $tag): Paginator;
 
-    public function search(string $toMatch): array;
+    public function search(string $toMatch): ?array;
 }

--- a/src/Blog/Mapper/PdoMapper.php
+++ b/src/Blog/Mapper/PdoMapper.php
@@ -61,7 +61,7 @@ class PdoMapper implements MapperInterface
         return $this->preparePaginator($select, $count, [':tag' => sprintf('%%|%s|%%', $tag)]);
     }
 
-    public function search(string $toMatch): array
+    public function search(string $toMatch): ?array
     {
         $select = $this->pdo->prepare('SELECT id, title from search WHERE search MATCH :query');
         if (! $select->execute([':query' => $toMatch])) {

--- a/src/Blog/Mapper/PdoPaginator.php
+++ b/src/Blog/Mapper/PdoPaginator.php
@@ -19,19 +19,15 @@ class PdoPaginator implements AdapterInterface
 {
     use CreateBlogPostFromDataArray;
 
-    /** @var int */
-    protected $count;
-
     /** @var array<string, mixed> */
     protected $params;
 
-    /** @var PDOStatement */
-    protected $select;
-
-    public function __construct(PDOStatement $select, PDOStatement $count, array $params = [])
-    {
-        $this->select = $select;
-        $this->count  = $count;
+    /** @param array<string, mixed> $params */
+    public function __construct(
+        protected PDOStatement $select,
+        protected PDOStatement $count,
+        array $params = [],
+    ) {
         $this->params = $params;
     }
 

--- a/src/Blog/PlatesFunctionsDelegator.php
+++ b/src/Blog/PlatesFunctionsDelegator.php
@@ -14,7 +14,7 @@ use function sprintf;
 
 class PlatesFunctionsDelegator implements ExtensionInterface
 {
-    public Template $template;
+    public ?Template $template = null;
 
     public function __invoke(ContainerInterface $container, string $name, callable $factory): Engine
     {
@@ -54,6 +54,10 @@ class PlatesFunctionsDelegator implements ExtensionInterface
 
     public function postUrl(BlogPost $post): string
     {
+        if (null === $this->template) {
+            return '';
+        }
+
         return $this->template->url('blog.post', ['id' => $post->id]);
     }
 }

--- a/src/ReleaseFeed/DisplayFeedHandlerFactory.php
+++ b/src/ReleaseFeed/DisplayFeedHandlerFactory.php
@@ -12,10 +12,15 @@ class DisplayFeedHandlerFactory
 {
     public function __invoke(ContainerInterface $container): DisplayFeedHandler
     {
-        return new DisplayFeedHandler(
-            $container->get(StreamFactoryInterface::class),
-            $container->get(ResponseFactoryInterface::class),
-            $container->get('config')['release-feed']['feed-file']
-        );
+        $streamFactory = $container->get(StreamFactoryInterface::class);
+        assert($streamFactory instanceof StreamFactoryInterface);
+
+        $responseFactory = $container->get(ResponseFactoryInterface::class);
+        assert($responseFactory instanceof ResponseFactoryInterface);
+
+        $feedFile = $container->get('config')['release-feed']['feed-file'] ?? '';
+        assert(is_string($feedFile) && '' !== $feedFile);
+
+        return new DisplayFeedHandler($streamFactory, $responseFactory, $feedFile);
     }
 }

--- a/src/ReleaseFeed/DisplayFeedHandlerFactory.php
+++ b/src/ReleaseFeed/DisplayFeedHandlerFactory.php
@@ -8,6 +8,9 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
+use function assert;
+use function is_string;
+
 class DisplayFeedHandlerFactory
 {
     public function __invoke(ContainerInterface $container): DisplayFeedHandler

--- a/src/ReleaseFeed/ReceiveFeedItemHandler.php
+++ b/src/ReleaseFeed/ReceiveFeedItemHandler.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+use function assert;
 use function explode;
 use function file_get_contents;
 use function file_put_contents;

--- a/src/ReleaseFeed/ReceiveFeedItemHandler.php
+++ b/src/ReleaseFeed/ReceiveFeedItemHandler.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use Exception;
 use Laminas\Feed\Reader\Reader;
 use Laminas\Feed\Writer\Feed;
-use League\CommonMark\MarkdownConverterInterface;
+use League\CommonMark\ConverterInterface;
 use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -28,7 +28,7 @@ class ReceiveFeedItemHandler implements RequestHandlerInterface
 {
     public function __construct(
         private string $feedFile,
-        private MarkdownConverterInterface $markdown,
+        private ConverterInterface $markdown,
         private ResponseFactoryInterface $responseFactory,
         private ProblemDetailsResponseFactory $problemFactory
     ) {
@@ -86,7 +86,7 @@ class ReceiveFeedItemHandler implements RequestHandlerInterface
             $data['package'],
             $data['version'],
             $data['url'],
-            $this->markdown->convertToHtml($data['changelog'])->getContent(),
+            $this->markdown->convert($data['changelog'])->getContent(),
             new DateTimeImmutable($data['publication_date']),
             new Author($data['author_name'], $authorUrl)
         );
@@ -100,7 +100,7 @@ class ReceiveFeedItemHandler implements RequestHandlerInterface
 
         foreach ($feed as $entry) {
             $title               = $entry->getTitle();
-            [$package, $version] = explode(' ', $title);
+            [$package, $version] = explode(' ', $title, 2);
 
             $author     = $entry->getAuthor();
             $authorName = $author['name'];
@@ -135,6 +135,7 @@ class ReceiveFeedItemHandler implements RequestHandlerInterface
 
         $latest = false;
         foreach ($releases as $release) {
+            assert($release instanceof Release);
             $latest = $latest ?: $release->date;
 
             $entry = $feed->createEntry();
@@ -149,8 +150,10 @@ class ReceiveFeedItemHandler implements RequestHandlerInterface
             $feed->addEntry($entry);
         }
 
-        $feed->setDateModified($latest);
-        $feed->setLastBuildDate($latest);
+        if ($latest !== false) {
+            $feed->setDateModified($latest);
+            $feed->setLastBuildDate($latest);
+        }
 
         return $feed;
     }

--- a/src/ReleaseFeed/ReceiveFeedItemHandlerFactory.php
+++ b/src/ReleaseFeed/ReceiveFeedItemHandlerFactory.php
@@ -14,6 +14,9 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use RuntimeException;
 
+use function assert;
+use function is_string;
+
 class ReceiveFeedItemHandlerFactory
 {
     public function __invoke(ContainerInterface $container): ReceiveFeedItemHandler

--- a/src/ReleaseFeed/ReceiveFeedItemHandlerFactory.php
+++ b/src/ReleaseFeed/ReceiveFeedItemHandlerFactory.php
@@ -12,21 +12,33 @@ use League\CommonMark\MarkdownConverter;
 use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
+use RuntimeException;
 
 class ReceiveFeedItemHandlerFactory
 {
     public function __invoke(ContainerInterface $container): ReceiveFeedItemHandler
     {
+        $feedFile = $container->get('config')['release-feed']['feed-file'] ?? '';
+        if (! is_string($feedFile) || '' === $feedFile) {
+            throw new RuntimeException('Missing release feed file name; must be a non-empty string');
+        }
+
         $env = new Environment();
         $env->addExtension(new CommonMarkCoreExtension());
         $env->addExtension(new GithubFlavoredMarkdownExtension());
         $env->addExtension(new TableExtension());
 
+        $responseFactory = $container->get(ResponseFactoryInterface::class);
+        assert($responseFactory instanceof ResponseFactoryInterface);
+
+        $problemDetailsFactory = $container->get(ProblemDetailsResponseFactory::class);
+        assert($problemDetailsFactory instanceof ProblemDetailsResponseFactory);
+
         return new ReceiveFeedItemHandler(
-            $container->get('config')['release-feed']['feed-file'],
+            $feedFile,
             new MarkdownConverter($env),
-            $container->get(ResponseFactoryInterface::class),
-            $container->get(ProblemDetailsResponseFactory::class)
+            $responseFactory,
+            $problemDetailsFactory,
         );
     }
 }

--- a/src/ReleaseFeed/Releases.php
+++ b/src/ReleaseFeed/Releases.php
@@ -15,6 +15,7 @@ use function usort;
 
 class Releases implements IteratorAggregate
 {
+    /** @psalm-var list<Release> */
     private array $releases = [];
 
     public function getIterator(): Iterator
@@ -29,14 +30,22 @@ class Releases implements IteratorAggregate
         $this->releases[] = $release;
     }
 
+    /**
+     * @psalm-param list<Release> $releases
+     * @psalm-return list<Release>
+     */
     private function sort(array $releases): array
     {
-        usort($releases, function (Release $a, Release $b) {
+        usort($releases, function (Release $a, Release $b): int {
             return $a->date <=> $b->date;
         });
         return array_reverse($releases);
     }
 
+    /**
+     * @psalm-param list<Release> $releases
+     * @psalm-return list<Release>
+     */
     private function truncate(array $releases): array
     {
         if (count($releases) < 30) {

--- a/src/ReleaseFeed/VerifyTokenMiddlewareFactory.php
+++ b/src/ReleaseFeed/VerifyTokenMiddlewareFactory.php
@@ -6,7 +6,9 @@ namespace GetLaminas\ReleaseFeed;
 
 use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
 use Psr\Container\ContainerInterface;
-use RuntimeException;
+
+use function assert;
+use function is_string;
 
 class VerifyTokenMiddlewareFactory
 {

--- a/src/ReleaseFeed/VerifyTokenMiddlewareFactory.php
+++ b/src/ReleaseFeed/VerifyTokenMiddlewareFactory.php
@@ -6,14 +6,18 @@ namespace GetLaminas\ReleaseFeed;
 
 use Mezzio\ProblemDetails\ProblemDetailsResponseFactory;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 
 class VerifyTokenMiddlewareFactory
 {
     public function __invoke(ContainerInterface $container): VerifyTokenMiddleware
     {
-        return new VerifyTokenMiddleware(
-            $container->get('config')['release-feed']['verification_token'],
-            $container->get(ProblemDetailsResponseFactory::class)
-        );
+        $token = $container->get('config')['release-feed']['verification_token'] ?? '';
+        assert(is_string($token) && '' !== $token);
+
+        $responseFactory = $container->get(ProblemDetailsResponseFactory::class);
+        assert($responseFactory instanceof ProblemDetailsResponseFactory);
+
+        return new VerifyTokenMiddleware($token, $responseFactory);
     }
 }

--- a/src/Security/Handler/AdvisoryHandlerFactory.php
+++ b/src/Security/Handler/AdvisoryHandlerFactory.php
@@ -8,6 +8,8 @@ use GetLaminas\Security\Advisory;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class AdvisoryHandlerFactory
 {
     public function __invoke(ContainerInterface $container): AdvisoryHandler

--- a/src/Security/Handler/AdvisoryHandlerFactory.php
+++ b/src/Security/Handler/AdvisoryHandlerFactory.php
@@ -13,7 +13,10 @@ class AdvisoryHandlerFactory
     public function __invoke(ContainerInterface $container): AdvisoryHandler
     {
         $advisory = $container->get(Advisory::class);
+        assert($advisory instanceof Advisory);
+
         $template = $container->get(TemplateRendererInterface::class);
+        assert($template instanceof TemplateRendererInterface);
 
         return new AdvisoryHandler($advisory, $template);
     }

--- a/src/Security/Handler/SecurityHandler.php
+++ b/src/Security/Handler/SecurityHandler.php
@@ -15,11 +15,13 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 
+use function array_keys;
 use function array_slice;
 use function basename;
 use function ceil;
 use function count;
 use function current;
+use function is_string;
 use function preg_match;
 use function sprintf;
 

--- a/src/Security/Handler/SecurityHandler.php
+++ b/src/Security/Handler/SecurityHandler.php
@@ -13,6 +13,7 @@ use Mezzio\Template;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 
 use function array_slice;
 use function basename;
@@ -101,18 +102,22 @@ class SecurityHandler implements RequestHandlerInterface
         $first      = current($advisories);
         $feed->setDateModified(new DateTimeImmutable($first['date']));
 
-        foreach ($advisories as $id => $advisory) {
+        foreach (array_keys($advisories) as $id) {
+            if (! is_string($id)) {
+                throw new RuntimeException('Unexpected feed identifier; expected string');
+            }
+
             $content = $this->advisory->getFromFile($id);
             $entry   = $feed->createEntry();
-            $entry->setTitle($content['title']);
-            $entry->setLink(sprintf('%s/%s', $advisoryUrl, basename($id, '.md')));
+            $entry->setTitle($content['title'] ?? '');
+            $entry->setLink(sprintf('%s/%s', (string) $advisoryUrl, basename($id, '.md')));
             $entry->addAuthor([
                 'name'  => 'Laminas Project Security',
                 'email' => 'security@getlaminas.org',
             ]);
-            $entry->setDateCreated(new DateTimeImmutable($content['date']));
-            $entry->setDateModified(new DateTimeImmutable($content['date']));
-            $entry->setContent($content['body']);
+            $entry->setDateCreated(new DateTimeImmutable($content['date'] ?? 'now'));
+            $entry->setDateModified(new DateTimeImmutable($content['date'] ?? 'now'));
+            $entry->setContent($content['body'] ?? '');
             $feed->addEntry($entry);
         }
 

--- a/src/Security/Handler/SecurityHandlerFactory.php
+++ b/src/Security/Handler/SecurityHandlerFactory.php
@@ -13,7 +13,10 @@ class SecurityHandlerFactory
     public function __invoke(ContainerInterface $container): SecurityHandler
     {
         $advisory = $container->get(Advisory::class);
+        assert($advisory instanceof Advisory);
+
         $template = $container->get(TemplateRendererInterface::class);
+        assert($template instanceof TemplateRendererInterface);
 
         return new SecurityHandler($advisory, $template);
     }

--- a/src/Security/Handler/SecurityHandlerFactory.php
+++ b/src/Security/Handler/SecurityHandlerFactory.php
@@ -8,6 +8,8 @@ use GetLaminas\Security\Advisory;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerInterface;
 
+use function assert;
+
 class SecurityHandlerFactory
 {
     public function __invoke(ContainerInterface $container): SecurityHandler


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

This patch adds Psalm to the QA pipeline, which should help us identify potential BC breaks, as well as changes in the type system.

I've added Psalm as a dev dependency, along with configuration. I then went through and fixed as many errors as were reasonable, primarily:

- adding type assertions in factories
- adding `@var` annotations where types are known, but Psalm could not infer them (e.g., anything laminas-feed related, anything to do with laminas-paginator, return values from PDO where we do casting).
- ensuring we have types specified wherever we can for properties, method parameters, and return values
- updating calls to deprecated functionality to use the recommended functionality

I've tested these changes locally, but we should also verify against Platform.sh (it's a standard check on this repo).
