### PR TITLE
Upgrade frontend tools

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -11,8 +11,8 @@ build:
 
 variables:
   env:
-    NVM_VERSION: v0.39.1
-    NODE_VERSION: v18.7.0
+    NVM_VERSION: v0.39.3
+    NODE_VERSION: v18.15.0
 
 dependencies:
   php:

--- a/bootstrap/build.sh
+++ b/bootstrap/build.sh
@@ -1,6 +1,0 @@
-rm dist/hackerthemes-theme-kit.zip -f
-mkdir dist -p
-gulp
-pushd ..
-find theme-kit \( -path '*/.*' -o -path 'theme-kit/node_modules*' -o -path 'dist*' \) -prune -o -type f -print | zip theme-kit/dist/hackerthemes-theme-kit.zip -@
-popd

--- a/bootstrap/build/.gitignore
+++ b/bootstrap/build/.gitignore
@@ -1,3 +1,2 @@
-*.css
-*.js
-assets.json
+*
+!.gitignore

--- a/bootstrap/gulpfile.mjs
+++ b/bootstrap/gulpfile.mjs
@@ -1,14 +1,14 @@
-'use strict';
+import autoprefixer from 'autoprefixer';
+import concat from 'gulp-concat';
+import cleanCss from 'gulp-clean-css';
+import gulp from 'gulp';
+import postcss from 'gulp-postcss';
+import rev from 'gulp-rev-all';
+import revCleaner from 'gulp-rev-dist-clean';
+import sass from 'gulp-dart-sass';
+import terser from'gulp-terser';
 
-const autoprefixer = require('autoprefixer');
-const concat = require('gulp-concat');
-const cleanCss = require('gulp-clean-css');
-const {series, src, dest, watch} = require('gulp');
-const postcss = require('gulp-postcss');
-const rev = require('gulp-rev-all');
-const revCleaner = require('gulp-rev-dist-clean').default;
-const sass = require('gulp-dart-sass');
-const terser = require('gulp-terser');
+const {series, src, dest, watch} = gulp;
 
 const prism = [
     'core',
@@ -108,26 +108,28 @@ function copyRev() {
         .pipe(dest('../data'));
 }
 
-exports.js = js;
-exports.css = css;
-exports.revGenerate = revGenerate;
-exports.revClean = revClean;
-exports.copyAssets = copyAssets;
-exports.copyRev = copyRev;
-exports.fonts = fonts;
+export {
+    js,
+    css,
+    revGenerate,
+    revClean,
+    copyAssets,
+    copyRev,
+    fonts
+};
 
 /* Primary build task
  * Add items to this series that need to occur when building the final
  * production image.
  */
-exports.deploy = series(js, fonts, css, revGenerate, revClean);
+export const deploy = series(js, fonts, css, revGenerate, revClean);
 
 /* Development build task
  * Add items to this series that need to occur when building assets during
  * development.
  */
-exports.develop = series(exports.deploy, copyAssets, copyRev);
+export const develop = series(deploy, copyAssets, copyRev);
 
-exports.default = () => {
-    watch('scss/*.scss', exports.develop);
+export default () => {
+    watch('scss/*.scss', develop);
 };

--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -1,15 +1,13 @@
 {
-  "name": "theme-kit",
-  "version": "1.0.1",
+  "name": "@laminas/getlaminas.org",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "theme-kit",
-      "version": "1.0.1",
-      "license": "MIT",
+      "name": "@laminas/getlaminas.org",
+      "license": "BSD-3-Clause",
       "devDependencies": {
-        "anchor-js": "^4.3.1",
+        "anchor-js": "^5.0.0",
         "autoprefixer": "^10.4.14",
         "bootstrap": "^4.6.2",
         "font-awesome": "^4.7.0",
@@ -24,6 +22,9 @@
         "jquery": "^3.6.4",
         "popper.js": "^1.16.1",
         "prismjs": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -151,9 +152,9 @@
       }
     },
     "node_modules/anchor-js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-4.3.1.tgz",
-      "integrity": "sha512-TziERoibspey7KSm95oIdzTxiogXonJl7inQI07Y3cI25DKQaLkUftB7RhCuSb1GcwunHL6/PcIKM4dDUb9xYQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/anchor-js/-/anchor-js-5.0.0.tgz",
+      "integrity": "sha512-2bOqCsBIXAYhjAN3iI4QevoAJtB2gRWAiY9P3P7CVW8lIjA3Dl6ldhDlWeeQvCHif+V5vIndfLOag/5I8tzTzA==",
       "dev": true
     },
     "node_modules/ansi-colors": {
@@ -702,9 +703,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001488",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
-      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
+      "version": "1.0.30001489",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
+      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
       "dev": true,
       "funding": [
         {
@@ -1245,9 +1246,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.398",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.398.tgz",
-      "integrity": "sha512-tT90Lmieb+Y4jX5Awub8BsvuFM/ICKr01oZFBR9Cy6pxCf+rAmwcpRl4xfXb66DzTXc4qSMPqlqLDoghm27utQ==",
+      "version": "1.4.404",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.404.tgz",
+      "integrity": "sha512-te57sWvQdpxmyd1GiswaodKdXdPgn9cN4ht8JlNa04QgtrfnUdWEo1261rY2vaC6TKaiHn0E7QerJWPKFCvMVw==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -3247,9 +3248,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
+      "integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -4993,9 +4994,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.4",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.4.tgz",
-      "integrity": "sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==",
+      "version": "5.17.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.5.tgz",
+      "integrity": "sha512-NqFkzBX34WExkCbk3K5urmNCpEWqMPZnwGI1pMHwqvJ/zDlXC75u3NI7BrzoR8/pryy8Abx2e1i8ChrWkhH1Hg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",

--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -18,7 +18,7 @@
         "gulp-concat": "^2.6.1",
         "gulp-dart-sass": "^1.1.0",
         "gulp-postcss": "^9.0.1",
-        "gulp-rev-all": "^3.0.0",
+        "gulp-rev-all": "^4.0.0",
         "gulp-rev-dist-clean": "^3.2.3",
         "gulp-terser": "^2.1.0",
         "jquery": "^3.6.4",
@@ -1232,6 +1232,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/easy-transform-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/easy-transform-stream/-/easy-transform-stream-1.0.0.tgz",
+      "integrity": "sha512-kIEXvPNtqUQ/lrgkULIP0/l2m88Ahlk2ySZhmuLdRidXBIEPyHuDgDt04b9DvnCy+nIQDjpygVft+Op3PZFUQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.398",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.398.tgz",
@@ -1504,6 +1516,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.2.0.tgz",
+      "integrity": "sha512-NcvQXt7Cky1cNau15FWy64IjuO8X0JijhTBBrJj1YlxlDfRkJXNaK9RFUjwpfDPzMdv7wB38jr53l9tkNLxnWg==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -2125,114 +2143,81 @@
       }
     },
     "node_modules/gulp-rev-all": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-rev-all/-/gulp-rev-all-3.0.0.tgz",
-      "integrity": "sha512-NJaiLopZA1f+OuUXcsmtwtB1aXZl/PaO0JRm/P8qwwGTJ6BR1OLASrKkehFNMxoylBbPGPfTxFR7BQ+EoaJIvQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev-all/-/gulp-rev-all-4.0.0.tgz",
+      "integrity": "sha512-qQYY56y6z9jJiZC+KpRtSCzFb/uS7bIGUB3tRiCyyQYr/Si3QkXX+t+UAceZ650d7y6yaqoO8xFKPRGHClXrJA==",
       "dev": true,
       "dependencies": {
-        "chalk": "^4.1.0",
-        "fancy-log": "^1.3.2",
-        "isbinaryfile": "^4.0.6",
-        "merge": "^2.1.1",
-        "plugin-error": "^1.0.1",
-        "through2": "^4.0.2",
-        "vinyl": "^2.2.1"
+        "chalk": "^5.2.0",
+        "easy-transform-stream": "^1.0.0",
+        "fancy-log": "^2.0.0",
+        "isbinaryfile": "^5.0.0",
+        "plugin-error": "^2.0.1",
+        "vinyl": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gulp-rev-all/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=16"
       }
     },
     "node_modules/gulp-rev-all/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/gulp-rev-all/node_modules/color-convert": {
+    "node_modules/gulp-rev-all/node_modules/fancy-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-2.0.0.tgz",
+      "integrity": "sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==",
+      "dev": true,
+      "dependencies": {
+        "color-support": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/gulp-rev-all/node_modules/plugin-error": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
+      "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
       "dev": true,
       "dependencies": {
-        "color-name": "~1.1.4"
+        "ansi-colors": "^1.0.1"
       },
       "engines": {
-        "node": ">=7.0.0"
+        "node": ">=10.13.0"
       }
     },
-    "node_modules/gulp-rev-all/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/gulp-rev-all/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+    "node_modules/gulp-rev-all/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">= 10"
       }
     },
-    "node_modules/gulp-rev-all/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+    "node_modules/gulp-rev-all/node_modules/vinyl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
+      "integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
       "dev": true,
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "clone": "^2.1.2",
+        "clone-stats": "^1.0.0",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/gulp-rev-all/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gulp-rev-all/node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "3"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/gulp-rev-dist-clean": {
@@ -2770,12 +2755,12 @@
       "dev": true
     },
     "node_modules/isbinaryfile": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
-      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.0.tgz",
+      "integrity": "sha512-UDdnyGvMajJUWCkib7Cei/dvyJrrvo4FIrsvSFWdPpXSUorzXrDJ0S+X5Q4ZlasfPjca4yqCNNsjbCeiy8FFeg==",
       "dev": true,
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 14.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/gjtorikian/"
@@ -3017,12 +3002,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/merge": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
-      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
-      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3910,6 +3889,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true
     },
     "node_modules/read-pkg": {
       "version": "1.1.0",
@@ -4886,6 +4871,16 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "node_modules/streamx": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.13.2.tgz",
+      "integrity": "sha512-+TWqixPhGDXEG9L/XczSbhfkmwAtGs3BJX5QNU6cvno+pOLKeszByWcnaTu6dg8efsTYqR8ZZuXWHhZfgrxMvA==",
+      "dev": true,
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -4986,6 +4981,15 @@
       "dependencies": {
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/terser": {

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -23,7 +23,7 @@
     "gulp-concat": "^2.6.1",
     "gulp-dart-sass": "^1.1.0",
     "gulp-postcss": "^9.0.1",
-    "gulp-rev-all": "^3.0.0",
+    "gulp-rev-all": "^4.0.0",
     "gulp-rev-dist-clean": "^3.2.3",
     "gulp-terser": "^2.1.0",
     "jquery": "^3.6.4",

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -1,20 +1,14 @@
 {
-  "name": "theme-kit",
-  "version": "1.0.1",
-  "description": "A starter project to build your own Bootstrap themes",
-  "repository": "https://github.com/HackerThemes/theme-kit",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "name": "@laminas/getlaminas.org",
+  "private": "true",
+  "description": "getlaminas.org Bootstrap based theme",
+  "repository": "https://github.com/laminas/getlaminas.org",
+  "engines": {
+    "node": "^18"
   },
-  "keywords": [
-    "bootstrap",
-    "themes"
-  ],
-  "author": "Alexander Rechsteiner",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "devDependencies": {
-    "anchor-js": "^4.3.1",
+    "anchor-js": "^5.0.0",
     "autoprefixer": "^10.4.14",
     "bootstrap": "^4.6.2",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
gulp-rev-all v4 has converted to ESM format. To accommodate the upgrade gulpfile is converted to ESM as well.

anchor-js is bumped to v5 but I was not able to verify if there are any problems. I am not sure where it is used.

This also includes few QA changes:
- convert package.json to be our own rather than starter kit
- drop unused build script from start kit
- bump minor node version

Supersedes #131 and #133  

