### PR TITLE
Revert renovate handling of php to replace strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,31 @@
     {
       "matchDepTypes": ["require"],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchPackageNames": ["php"],
+      "rangeStrategy": "replace",
+      "groupName": "PHP"
+    },
+    {
+      "matchFiles": [".platform.app.yaml"],
+      "matchPackageNames": ["php/php-src"],
+      "extends": [":automergeDisabled", ":automergePr", ":label(Awaiting Maintainer Response)"],
+      "groupName": "PHP",
+      "commitMessageTopic": "platform.sh PHP",
+      "prBodyNotes": [
+        ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"
+      ]
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^.platform.app.yaml$"],
+      "matchStrings": ["\\ntype: php:(?<currentValue>.*)\\n"],
+      "depNameTemplate": "php/php-src",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)\\.\\d+$",
+      "versioningTemplate": "semver-coerced"
     }
   ]
 }


### PR DESCRIPTION
This PR mimics changes from laminas/laminas.dev 

Renovate config for this repository sets strategy for require deps to `bump` which is not what we want for PHP. This reverts strategy for PHP specifically to `replace`.
Additional lookup is added for php releases to bump platform.sh version. It is not a true lookup as platform version is an environment named after php version it uses and it might or might not be available at the time of PR.