### PR TITLE
Downgrade composer to 2.5 until 2.7

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,7 +16,7 @@ variables:
 
 dependencies:
   php:
-    "composer/composer": "^2"
+    "composer/composer": "~2.5.8"
   nodejs:
     gulp-cli: '~2.3.0'
 


### PR DESCRIPTION
Composer 2.6 allows symfony/console v7 but is not compatible with it. Since console released last week builds are failing.
Downgrade composer to 2.5 until 2.7 was released with proper support.