### PR TITLE
initial property listing page and data generation command

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,4 +1,4 @@
-name: testing_getlaminas_org
+name: getlaminas_org
 
 type: php:8.2
 

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -1,4 +1,4 @@
-name: getlaminas_org
+name: testing_getlaminas_org
 
 type: php:8.2
 
@@ -24,6 +24,9 @@ mounts:
   'data/cache':
     source: local
     source_path: data/cache
+  'public/share':
+    source: local
+    source_path: public/share
 
 hooks:
   build: |
@@ -52,22 +55,34 @@ hooks:
   deploy: |
     rm -f data/cache/config-cache.php
     if [ ! -e data/cache/releases.rss ];then cp templates/releases.rss data/cache/ ;fi
+    if [ "$PLATFORM_BRANCH" = staging ]; then
+      ./vendor/bin/laminas repository:generate-data "$PLATFORM_VARIABLES" | base64 --decode | jq '."REPO_TOKEN"'
+    fi
 
 crons:
-    snapshot:
-        # Take a snapshot automatically every night at 3 am (UTC).
-        spec: '0 3 * * *'
-        cmd: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
-                platform snapshot:create --yes --no-wait
-            fi
-    renewcert:
-        # Force a redeploy at 8 am (UTC) on the 14th and 28th of every month.
-        spec: '0 8 14,28 * *'
-        cmd: |
-            if [ "$PLATFORM_BRANCH" = master ]; then
-                platform redeploy --yes --no-wait
-            fi
+  snapshot:
+    # Take a snapshot automatically every night at 3 am (UTC).
+    spec: '0 3 * * *'
+    cmd: |
+      if [ "$PLATFORM_BRANCH" = master ]; then
+          platform snapshot:create --yes --no-wait
+      fi
+  renewcert:
+    # Force a redeploy at 8 am (UTC) on the 14th and 28th of every month.
+    spec: '0 8 14,28 * *'
+    cmd: |
+      if [ "$PLATFORM_BRANCH" = master ]; then
+          platform redeploy --yes --no-wait
+      fi
+  generatedata:
+    # Refresh repository data every night at 2 am (UTC).
+    spec: '0 2 * * * *'
+    commands :
+      start: |
+        if [ "$PLATFORM_BRANCH" = staging ]; then
+           ./vendor/bin/laminas repository:generate-data "$PLATFORM_VARIABLES" | base64 --decode | jq '."REPO_TOKEN"'
+        fi
+    shutdown_timeout: 20
 
 web:
   locations:

--- a/bootstrap/scss/_custom-styles.scss
+++ b/bootstrap/scss/_custom-styles.scss
@@ -188,3 +188,74 @@ article {
         background: $dropdown-link-active-bg;
     }
 }
+
+/*
+ * Repository data section
+ */
+.repository-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+@media(max-width:600px) {
+    .repository-container {
+        flex-direction: column;
+    }
+}
+
+.repo-property-name.active {
+    --repo-value: #03711d;
+}
+
+.repo-property-name.false {
+    --repo-value: #6c2e2e;
+}
+
+.repository-organization.laminas {
+    --org-color: #E64010FF;
+}
+
+.repository-organization.laminas-api-tools {
+    --org-color: #C71F38;
+}
+
+.repository-organization.mezzio {
+    --org-color: #009655FF;
+}
+
+.repository-organization {
+    border: 1px solid var(--org-color);
+    border-radius: .25rem;
+    height: fit-content;
+
+    h1 {
+        color: white;
+        font-size: 1.5rem;
+        border-radius: calc(.25rem - 1px) calc(.25rem - 1px) 0 0;
+        background-color: var(--org-color);
+        padding: .75rem 1.25rem;
+    }
+
+    .repository-card-container {
+    }
+
+    .repo-properties {
+        display: flex;
+        gap: 1rem;
+    }
+
+    .repo-property-name {
+        font-weight: bold;
+    }
+
+    .card-body {
+        padding: .75rem;
+    }
+}
+
+#repository-last-updated {
+    font-style: italic;
+    font-size: .8rem;
+}

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "require": {
         "php": "~8.2.0",
         "ext-pdo": "*",
+        "ext-curl": "*",
         "dflydev/fig-cookies": "^3.1.0",
         "laminas/laminas-cli": "^1.10.0",
         "laminas/laminas-component-installer": "^3.4.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="bin/clear-config-cache.php">
     <MixedArgument>
       <code><![CDATA[$config['config_cache_path']]]></code>
@@ -41,6 +41,11 @@
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$this->collection]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="src/App/Console/WriteRepositoryData.php">
+    <MixedAssignment>
+      <code>$token</code>
     </MixedAssignment>
   </file>
   <file src="src/App/ContentParser/Document.php">
@@ -267,5 +272,10 @@
       <code>$action</code>
       <code>$first</code>
     </MixedAssignment>
+  </file>
+  <file src="vendor/symfony/console/Command/Command.php">
+    <PossiblyNullArgument>
+      <code>$name</code>
+    </PossiblyNullArgument>
   </file>
 </files>

--- a/src/App/ConfigProvider.php
+++ b/src/App/ConfigProvider.php
@@ -35,6 +35,7 @@ class ConfigProvider
             'commercial-vendors' => [],
             'dependencies'       => $this->getDependencies(),
             'templates'          => $this->getTemplates(),
+            'laminas-cli'        => $this->getConsoleConfig(),
         ];
     }
 
@@ -58,10 +59,20 @@ class ConfigProvider
             'factories'  => [
                 EventDispatcherInterface::class         => EventDispatcherFactory::class,
                 Handler\CommercialVendorsHandler::class => Handler\CommercialVendorsHandlerFactory::class,
+                Handler\CustomPropertiesHandler::class  => Handler\CustomPropertiesHandlerFactory::class,
                 Handler\HomePageHandler::class          => Handler\HomePageHandlerFactory::class,
                 Handler\StaticPageHandler::class        => Handler\StaticPageHandlerFactory::class,
                 LoggerInterface::class                  => AccessLoggerFactory::class,
                 PlatesEngine::class                     => PlatesEngineFactory::class,
+            ],
+        ];
+    }
+
+    public function getConsoleConfig(): array
+    {
+        return [
+            'commands' => [
+                'repository:generate-data' => Console\WriteRepositoryData::class,
             ],
         ];
     }
@@ -97,6 +108,7 @@ class ConfigProvider
         $app->get($basePath . 'participate[/]', Handler\StaticPageHandler::class, 'community.participate');
         $app->get($basePath . 'support[/]', Handler\StaticPageHandler::class, 'app.support');
         $app->get($basePath . 'commercial-vendor-program[/]', Handler\CommercialVendorsHandler::class, 'app.commercial-vendor-program');
+        $app->get($basePath . 'packages-custom-properties[/]', Handler\CustomPropertiesHandler::class, 'app.packages-custom-properties');
         // phpcs:enable Generic.Files.LineLength.TooLong
     }
 }

--- a/src/App/Console/WriteRepositoryData.php
+++ b/src/App/Console/WriteRepositoryData.php
@@ -83,9 +83,7 @@ class WriteRepositoryData extends Command
             assert(isset($variables['REPO_TOKEN']));
 
             $token = $variables['REPO_TOKEN'];
-            assert(is_string($token));
         }
-
         assert(is_string($token));
 
         $this->generateDataFile($userAgent, $token);

--- a/src/App/Console/WriteRepositoryData.php
+++ b/src/App/Console/WriteRepositoryData.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function assert;
+use function base64_decode;
+use function count;
+use function curl_close;
+use function curl_exec;
+use function curl_init;
+use function curl_setopt;
+use function date;
+use function file_put_contents;
+use function getcwd;
+use function in_array;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function sprintf;
+
+use const CURLOPT_FOLLOWLOCATION;
+use const CURLOPT_HTTPHEADER;
+use const CURLOPT_RETURNTRANSFER;
+use const CURLOPT_URL;
+use const FILE_USE_INCLUDE_PATH;
+use const JSON_PRETTY_PRINT;
+
+class WriteRepositoryData extends Command
+{
+    private const ARGUMENT_USER_AGENT = 'userAgent';
+    private const ARGUMENT_TOKEN      = 'token';
+
+    private string $propsFile;
+    private string $cachePath;
+
+    private array $orgs = [
+        'laminas',
+        'laminas-api-tools',
+        'mezzio',
+    ];
+
+    private array $exceptions = [];
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->propsFile = 'properties.json';
+        $this->cachePath = getcwd() . "/public/share";
+    }
+
+    protected function configure(): void
+    {
+        $this->setName('app:generate-repository-data');
+        $this->setDescription('Write repository data to a json file.');
+        $this->setHelp(
+            'Writes all custom properties from all repositories of the configured organizations to a json file.'
+        );
+        $this->addArgument(self::ARGUMENT_USER_AGENT, InputArgument::OPTIONAL, 'GitHub user agent.');
+        $this->addArgument(self::ARGUMENT_TOKEN, InputArgument::OPTIONAL, 'GitHub token.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $userAgent = $input->getArgument(self::ARGUMENT_USER_AGENT);
+        if (! $userAgent) {
+            $userAgent = $_ENV['PLATFORM_APPLICATION_NAME'];
+        }
+        assert(is_string($userAgent));
+
+        $token = $input->getArgument(self::ARGUMENT_TOKEN);
+        if (! $token) {
+            $variables = json_decode(base64_decode($_ENV['PLATFORM_VARIABLES']), true);
+            assert(is_array($variables));
+            assert(isset($variables['REPO_TOKEN']));
+
+            $token = $variables['REPO_TOKEN'];
+            assert(is_string($token));
+        }
+
+        assert(is_string($token));
+
+        $this->generateDataFile($userAgent, $token);
+
+        return 0;
+    }
+
+    private function generateDataFile(string $userAgent, string $token): void
+    {
+        $headers = [
+            'Accept: application/vnd.github+json',
+            'User-Agent: ' . $userAgent,
+            'Authorization: Bearer ' . $token,
+            'X-GitHub-Api-Version: 2022-11-28',
+        ];
+
+        $curl = curl_init();
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+        $singleResult = ['last_updated' => date('Y-m-d H:i:s')];
+
+        /** @var string $org */
+        foreach ($this->orgs as $org) {
+            $perPage = 100;
+            $page    = 1;
+
+            do {
+                $query = "per_page=$perPage&page=$page";
+                $url   = "https://api.github.com/orgs/" . $org . "/properties/values?$query";
+
+                curl_setopt($curl, CURLOPT_URL, $url);
+
+                $curlResult = curl_exec($curl);
+                assert(is_string($curlResult));
+
+                $decodedRes = json_decode($curlResult, true);
+                assert(is_array($decodedRes));
+
+                /** @var array $value */
+                foreach ($decodedRes as $value) {
+                    if (in_array($value['repository_name'], $this->exceptions)) {
+                        continue;
+                    }
+
+                    $singleResult[$org][] = [
+                        'name'       => $value['repository_name'],
+                        'properties' => $value['properties'],
+                    ];
+                }
+
+                $page++;
+            } while (count($decodedRes) === $perPage);
+        }
+
+        file_put_contents(
+            sprintf('%s/%s', $this->cachePath, $this->propsFile),
+            json_encode($singleResult, JSON_PRETTY_PRINT),
+            FILE_USE_INCLUDE_PATH
+        );
+
+        curl_close($curl);
+    }
+}

--- a/src/App/Handler/CustomPropertiesHandler.php
+++ b/src/App/Handler/CustomPropertiesHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class CustomPropertiesHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private array $repositoryData,
+        private string $lastUpdated,
+        private TemplateRendererInterface $renderer
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new HtmlResponse($this->renderer->render(
+            'app::packages-custom-properties',
+            [
+                'repositoryData' => $this->repositoryData,
+                'lastUpdated'    => $this->lastUpdated,
+            ],
+        ));
+    }
+}

--- a/src/App/Handler/CustomPropertiesHandlerFactory.php
+++ b/src/App/Handler/CustomPropertiesHandlerFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+use function assert;
+use function file_get_contents;
+use function getcwd;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function sprintf;
+
+class CustomPropertiesHandlerFactory
+{
+    /**
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(ContainerInterface $container): CustomPropertiesHandler
+    {
+        $rawData        = file_get_contents(sprintf('%s/%s', getcwd() . "/public/share", 'properties.json'));
+        $repositoryData = json_decode($rawData, true);
+        assert(is_array($repositoryData));
+
+        $renderer = $container->get(TemplateRendererInterface::class);
+        assert($renderer instanceof TemplateRendererInterface);
+
+        $lastUpdated = $repositoryData['last_updated'];
+        assert(is_string($lastUpdated));
+        unset($repositoryData['last_updated']);
+
+        return new CustomPropertiesHandler($repositoryData, $lastUpdated, $renderer);
+    }
+}

--- a/templates/app/packages-custom-properties.phtml
+++ b/templates/app/packages-custom-properties.phtml
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var League\Plates\Template\Template $this
+ * @var string $lastUpdated
+ * @var array $repositoryData
+ */
+
+$this->layout('layout::default', ['title' => 'Packages Custom Properties']);
+
+const GITHUB_URL = 'https://github.com/';
+
+$this->start('styles');
+$this->insert('blog::styles');
+$this->stop();
+
+$this->push('scripts');
+$this->insert('blog::scripts');
+$this->end();
+
+?>
+<div class="container">
+    <div class="row mt-5">
+        <div class="col">
+            <h1>Packages Custom Properties</h1>
+        </div>
+    </div>
+
+    <div class="repository-container">
+        <?php foreach($repositoryData as $organization => $orgData): ?>
+            <div class="repository-organization <?= $organization ?>">
+                <h1><?= $organization ?></h1>
+                <div class="repository-card-container">
+                    <?php foreach($orgData as $i => $data): ?>
+                        <div class="repository-card">
+                            <div class="card-body">
+                                <h5 class="card-title">
+                                    <a
+                                            target="_blank"
+                                            href="<?= GITHUB_URL . $organization . DIRECTORY_SEPARATOR . $data['name']
+                                            ?>">
+                                        <?= $data['name'] ?>
+                                    </a>
+                                </h5>
+                                <?php foreach ($data['properties'] as $property): ?>
+                                    <div class="repo-properties">
+                                        <p class="repo-property-name">
+                                            <?= ucwords(str_replace('-', ' ', $property['property_name'])) ?>:
+                                        </p>
+                                        <p class="repo-property-value"><?= $property['value'] ?></p>
+                                    </div>
+                                <?php endforeach;?>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        <?php endforeach ?>
+    </div>
+    <p id="repository-last-updated">Last update: <?= $lastUpdated ?></p>
+</div>


### PR DESCRIPTION
@arhimede Here is the requested initial version of the custom property listing page and its command to generate and save a json file containing the relevant data. You will require setting up the "REPO_TOKEN" variable on the staging environment in platform.sh to allow the calls to the github API.

The page is only accessible via url, via the "/packages-custom-properties" route.
For now, repository properties are simply displayed as a key-value pair, with the possibility of adding shield.io badges using dynamic badges such as ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Flaminas%2Flaminas-mail%2Fproperties%2Fvalues&query=%24%5B%3F(%40.property_name%3D%3D%22is-deprecated%22)%5D.value&label=is-deprecated).

The issue with displaying badges for all laminas, mezzio and laminas-api-tools packages on one page is hitting upstream limit, but I will keep looking into it.

I will also keep working on the code itself.
