### PR TITLE
Added maintenance-mode legend, minutes links

### DIFF
--- a/bootstrap/scss/_custom-styles.scss
+++ b/bootstrap/scss/_custom-styles.scss
@@ -213,6 +213,10 @@ article {
     --prop-value-color: #cda519;
 }
 
+.repo-property-value.discontinued, {
+    --prop-value-color: #d43442;
+}
+
 .repo-property-value.is-deprecated.false {
     --prop-value-color: #4cc61e;
 }
@@ -247,31 +251,64 @@ article {
         padding: .75rem 1.25rem;
     }
 
-    .repo-properties {
-        display: flex;
-        line-height: 1.8;
-    }
-
-    .repo-property-name {
-        font-size: .75rem;
-        background-color: #4e4e4e;
-        color: #fff;
-        border-radius: .25rem 0 0 .25rem;
-        padding: 0 .15rem
-    }
-
-    .repo-property-value {
-        font-size: .75rem;
-        background-color: var(--prop-value-color, #cda519);
-        color: #fff;
-        border-color: var(--prop-value-color, #cda519);
-        border-radius: 0 .25rem .25rem 0;
-        padding: 0 .15rem;
-    }
-
     .card-body {
         padding: 0 .75rem;
     }
+}
+
+.repo-properties {
+    display: flex;
+    line-height: 1.8;
+}
+
+#repository-legend {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    border: 1px solid rgba(0,0,0,.125);
+    border-radius: .25rem;
+    padding: .5rem;
+    margin-bottom: .5rem;
+
+    :last-child * {
+        margin-bottom: 0;
+    }
+
+    .legend-item {
+        display: flex;
+    }
+
+    .repo-legend-text {
+        margin-left: 1rem;
+        line-height: normal;
+    }
+
+    @media(max-width:600px) {
+        .legend-item {
+            flex-direction: column;
+        }
+
+        .repo-legend-text {
+            margin-left: 0;
+        }
+    }
+}
+
+.repo-property-name {
+    font-size: .75rem;
+    background-color: #4e4e4e;
+    color: #fff;
+    border-radius: .25rem 0 0 .25rem;
+    padding: 0 .15rem
+}
+
+.repo-property-value {
+    font-size: .75rem;
+    background-color: var(--prop-value-color, #cda519);
+    color: #fff;
+    border-color: var(--prop-value-color, #cda519);
+    border-radius: 0 .25rem .25rem 0;
+    padding: 0 .15rem;
 }
 
 #repository-last-updated {

--- a/templates/app/packages-custom-properties.phtml
+++ b/templates/app/packages-custom-properties.phtml
@@ -28,6 +28,39 @@ $this->end();
         </div>
     </div>
 
+    <div id="repository-legend">
+        <div class="legend-item">
+            <div class="repo-properties">
+                <p class="repo-property-name">Maintenance Mode</p>
+                <p class="repo-property-value active">active</p>
+            </div>
+            <p class="repo-legend-text">The repository is actively being supported</p>
+        </div>
+
+        <div class="legend-item">
+            <div class="repo-properties">
+                <p class="repo-property-name">Maintenance Mode</p>
+                <p class="repo-property-value security-only">maintenance-only</p>
+            </div>
+            <p class="repo-legend-text">The repository is only receiving support for bugs and security features</p>
+        </div>
+
+        <div class="legend-item">
+            <div class="repo-properties">
+                <p class="repo-property-name">Maintenance Mode</p>
+                <p class="repo-property-value security-only">security-only</p>
+            </div>
+            <p class="repo-legend-text">The repository is only receiving critical security support</p>
+        </div>
+
+        <div class="legend-item">
+            <div class="repo-properties">
+                <p class="repo-property-name">Maintenance Mode</p>
+                <p class="repo-property-value discontinued">discontinued</p>
+            </div>
+            <p class="repo-legend-text">The repository is no longer being supported</p>
+        </div>
+    </div>
     <div class="repository-container">
         <?php foreach($repositoryData as $organization => $orgData): ?>
             <div class="repository-organization <?= $organization ?>">
@@ -50,7 +83,13 @@ $this->end();
                                             <p class="repo-property-name">
                                                 <?= ucwords(str_replace('-', ' ', $property['property_name'])) ?>
                                             </p>
-                                            <p class="repo-property-value  <?= $property['property_name'] . ' ' . $property['value'] ?>"><?= $property['value'] ?></p>
+                                            <?php if ($property['property_name'] === 'maintenance-mode-minutes') : ?>
+                                                <a href="<?= sprintf('https://github.com/%s/technical-steering-committee/blob/main/meetings/minutes/%s', $organization, $property['value']) ?>" target="_blank">
+                                                    <p class="repo-property-value  <?= $property['property_name'] . ' ' . $property['value'] ?>"><?= $property['value'] ?></p>
+                                                </a>
+                                            <?php else: ?>
+                                                <p class="repo-property-value  <?= $property['property_name'] . ' ' . $property['value'] ?>"><?= $property['value'] ?></p>
+                                            <?php endif ?>
                                         </div>
                                     <?php endif?>
                                 <?php endforeach;?>

--- a/templates/partials/navigation.phtml
+++ b/templates/partials/navigation.phtml
@@ -43,6 +43,11 @@ declare(strict_types=1);
                        href="<?= $this->url('community.participate') ?>"
                        href="<?= $this->url('community.participate') ?>">Community</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link<?= str_starts_with($this->url(), $this->url('app.packages-custom-properties')) ? ' active' : '' ?>"
+                       href="<?= $this->url('app.packages-custom-properties') ?>"
+                       href="<?= $this->url('app.packages-custom-properties') ?>">Packages</a>
+                </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle<?= str_starts_with($this->url(), $this->url('app.support')) || str_starts_with($this->url(), $this->url('app.commercial-vendor-program')) ? ' active' : '' ?>"
                        href="<?= $this->url('app.support') ?>"


### PR DESCRIPTION
@arhimede added a legend for the "maintenance-mode" property on the listing page, included said listing page in the navbar. "Maintenance mode minutes" properties now link to the relevant file on github. 

Replaced the "exceptions array" with a package name filter