### PR TITLE
display 404 page on invalid URL

### DIFF
--- a/templates/partials/navigation.phtml
+++ b/templates/partials/navigation.phtml
@@ -5,13 +5,7 @@ declare(strict_types=1);
 /**
  * @var League\Plates\Template\Template $this
  */
-$currentUrl = null;
-try {
-    $currentUrl = $this->url();
-} catch (Throwable $e) {
-    // While accessing a nonexistent URL, $this->url() will throw an exception
-    // which prevents the 404 template from being rendered
-}
+$currentUrl = parse_url($this->serverurl(), PHP_URL_PATH);
 ?>
 <nav class="navbar navbar-expand-sm navbar-light bg-white fixed-top shadow">
     <div class="container">
@@ -26,37 +20,37 @@ try {
         <div class="collapse navbar-collapse" id="navbarCollapse">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle<?= $currentUrl && str_starts_with($currentUrl, $this->url('about.overview')) || $currentUrl && str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>"
+                    <a class="nav-link dropdown-toggle<?= str_starts_with($currentUrl, $this->url('about.overview')) || str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>"
                        href="#"
                        data-toggle="dropdown"
                        aria-expanded="false">About</a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('about.overview') ? ' active' : '' ?>" href="<?= $this->url('about.overview') ?>">Overview</a>
-                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('about.tsc') || $currentUrl === $this->url('about.join') ? ' active' : '' ?>" href="<?= $this->url('about.tsc') ?>">Technical Steering Committee</a>
-                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('about.foundation') ? ' active' : '' ?>" href="<?= $this->url('about.foundation') ?>">About the Foundation</a>
-                        <a class="dropdown-item<?= $currentUrl && str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>" href="<?= $this->url('security') ?>">Security</a>
+                        <a class="dropdown-item<?= $currentUrl === $this->url('about.overview') ? ' active' : '' ?>" href="<?= $this->url('about.overview') ?>">Overview</a>
+                        <a class="dropdown-item<?= $currentUrl === $this->url('about.tsc') || $currentUrl === $this->url('about.join') ? ' active' : '' ?>" href="<?= $this->url('about.tsc') ?>">Technical Steering Committee</a>
+                        <a class="dropdown-item<?= $currentUrl === $this->url('about.foundation') ? ' active' : '' ?>" href="<?= $this->url('about.foundation') ?>">About the Foundation</a>
+                        <a class="dropdown-item<?= str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>" href="<?= $this->url('security') ?>">Security</a>
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link<?= $currentUrl && str_starts_with($currentUrl, $this->url('blog')) ? ' active' : '' ?>"
+                    <a class="nav-link<?= str_starts_with($currentUrl, $this->url('blog')) ? ' active' : '' ?>"
                        href="<?= $this->url('blog') ?>">Blog</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://docs.laminas.dev">Docs</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link<?= $currentUrl && str_starts_with($currentUrl, $this->url('community.participate')) ? ' active' : '' ?>"
+                    <a class="nav-link<?= str_starts_with($currentUrl, $this->url('community.participate')) ? ' active' : '' ?>"
                        href="<?= $this->url('community.participate') ?>">Community</a>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle<?= $currentUrl && str_starts_with($currentUrl, $this->url('app.support')) || $currentUrl && str_starts_with($currentUrl, $this->url('app.commercial-vendor-program')) ? ' active' : '' ?>"
+                    <a class="nav-link dropdown-toggle<?= str_starts_with($currentUrl, $this->url('app.support')) || str_starts_with($currentUrl, $this->url('app.commercial-vendor-program')) ? ' active' : '' ?>"
                        href="<?= $this->url('app.support') ?>"
                        data-toggle="dropdown"
                        aria-expanded="false">Support Laminas</a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('app.support') ? ' active' : '' ?>" href="<?= $this->url('app.support') ?>">Overview</a>
+                        <a class="dropdown-item<?= $currentUrl === $this->url('app.support') ? ' active' : '' ?>" href="<?= $this->url('app.support') ?>">Overview</a>
                         <a class="dropdown-item" href="https://crowdfunding.lfx.linuxfoundation.org/projects/laminas-project" target="_blank">Sponsor Laminas Development <i class="bi-box-arrow-up-right"></i></a>
-                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('app.commercial-vendor-program') ? ' active' : '' ?>" href="<?= $this->url('app.commercial-vendor-program') ?>">Commercial Vendor Program</a>
+                        <a class="dropdown-item<?= $currentUrl === $this->url('app.commercial-vendor-program') ? ' active' : '' ?>" href="<?= $this->url('app.commercial-vendor-program') ?>">Commercial Vendor Program</a>
                     </div>
                 </li>
             </ul>

--- a/templates/partials/navigation.phtml
+++ b/templates/partials/navigation.phtml
@@ -5,6 +5,13 @@ declare(strict_types=1);
 /**
  * @var League\Plates\Template\Template $this
  */
+$currentUrl = null;
+try {
+    $currentUrl = $this->url();
+} catch (Throwable $e) {
+    // While accessing a nonexistent URL, $this->url() will throw an exception
+    // which prevents the 404 template from being rendered
+}
 ?>
 <nav class="navbar navbar-expand-sm navbar-light bg-white fixed-top shadow">
     <div class="container">
@@ -19,40 +26,37 @@ declare(strict_types=1);
         <div class="collapse navbar-collapse" id="navbarCollapse">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle<?= str_starts_with($this->url(), $this->url('about.overview')) || str_starts_with($this->url(), $this->url('security')) ? ' active' : '' ?>"
+                    <a class="nav-link dropdown-toggle<?= $currentUrl && str_starts_with($currentUrl, $this->url('about.overview')) || $currentUrl && str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>"
                        href="#"
                        data-toggle="dropdown"
                        aria-expanded="false">About</a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item<?= $this->url() === $this->url('about.overview') ? ' active' : '' ?>" href="<?= $this->url('about.overview') ?>">Overview</a>
-                        <a class="dropdown-item<?= $this->url() === $this->url('about.tsc') || $this->url() === $this->url('about.join') ? ' active' : '' ?>" href="<?= $this->url('about.tsc') ?>">Technical Steering Committee</a>
-                        <a class="dropdown-item<?= $this->url() === $this->url('about.foundation') ? ' active' : '' ?>" href="<?= $this->url('about.foundation') ?>">About the Foundation</a>
-                        <a class="dropdown-item<?= str_starts_with($this->url(), $this->url('security')) ? ' active' : '' ?>" href="<?= $this->url('security') ?>">Security</a>
+                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('about.overview') ? ' active' : '' ?>" href="<?= $this->url('about.overview') ?>">Overview</a>
+                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('about.tsc') || $currentUrl === $this->url('about.join') ? ' active' : '' ?>" href="<?= $this->url('about.tsc') ?>">Technical Steering Committee</a>
+                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('about.foundation') ? ' active' : '' ?>" href="<?= $this->url('about.foundation') ?>">About the Foundation</a>
+                        <a class="dropdown-item<?= $currentUrl && str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>" href="<?= $this->url('security') ?>">Security</a>
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link<?= str_starts_with($this->url(), $this->url('blog')) ? ' active' : '' ?>"
-                       href="<?= $this->url('blog') ?>"
+                    <a class="nav-link<?= $currentUrl && str_starts_with($currentUrl, $this->url('blog')) ? ' active' : '' ?>"
                        href="<?= $this->url('blog') ?>">Blog</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://docs.laminas.dev">Docs</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link<?= str_starts_with($this->url(), $this->url('community.participate')) ? ' active' : '' ?>"
-                       href="<?= $this->url('community.participate') ?>"
+                    <a class="nav-link<?= $currentUrl && str_starts_with($currentUrl, $this->url('community.participate')) ? ' active' : '' ?>"
                        href="<?= $this->url('community.participate') ?>">Community</a>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle<?= str_starts_with($this->url(), $this->url('app.support')) || str_starts_with($this->url(), $this->url('app.commercial-vendor-program')) ? ' active' : '' ?>"
+                    <a class="nav-link dropdown-toggle<?= $currentUrl && str_starts_with($currentUrl, $this->url('app.support')) || $currentUrl && str_starts_with($currentUrl, $this->url('app.commercial-vendor-program')) ? ' active' : '' ?>"
                        href="<?= $this->url('app.support') ?>"
-                       href="#"
                        data-toggle="dropdown"
                        aria-expanded="false">Support Laminas</a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item<?= $this->url() === $this->url('app.support') ? ' active' : '' ?>" href="<?= $this->url('app.support') ?>">Overview</a>
+                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('app.support') ? ' active' : '' ?>" href="<?= $this->url('app.support') ?>">Overview</a>
                         <a class="dropdown-item" href="https://crowdfunding.lfx.linuxfoundation.org/projects/laminas-project" target="_blank">Sponsor Laminas Development <i class="bi-box-arrow-up-right"></i></a>
-                        <a class="dropdown-item<?= $this->url() === $this->url('app.commercial-vendor-program') ? ' active' : '' ?>" href="<?= $this->url('app.commercial-vendor-program') ?>">Commercial Vendor Program</a>
+                        <a class="dropdown-item<?= $currentUrl && $currentUrl === $this->url('app.commercial-vendor-program') ? ' active' : '' ?>" href="<?= $this->url('app.commercial-vendor-program') ?>">Commercial Vendor Program</a>
                     </div>
                 </li>
             </ul>

--- a/templates/partials/navigation.phtml
+++ b/templates/partials/navigation.phtml
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @var League\Plates\Template\Template $this
  */
-$currentUrl = parse_url($this->serverurl(), PHP_URL_PATH);
+$currentUrl = rtrim(parse_url($this->serverurl(), PHP_URL_PATH), '/');
 
 $isCurrentRoute = function (string $routeName) use ($currentUrl): bool {
     $routeUrl = rtrim($this->url($routeName), '/');

--- a/templates/partials/navigation.phtml
+++ b/templates/partials/navigation.phtml
@@ -6,6 +6,17 @@ declare(strict_types=1);
  * @var League\Plates\Template\Template $this
  */
 $currentUrl = parse_url($this->serverurl(), PHP_URL_PATH);
+
+$isCurrentRoute = function (string $routeName) use ($currentUrl): bool {
+    $routeUrl = rtrim($this->url($routeName), '/');
+    return $currentUrl === $routeUrl;
+};
+
+$isRouteSubpath = function (string $routeName) use ($currentUrl): bool {
+    $routeUrl = rtrim($this->url($routeName), '/') . '/';
+    $currentUrl .= '/';
+    return str_starts_with($currentUrl, $routeUrl);
+};
 ?>
 <nav class="navbar navbar-expand-sm navbar-light bg-white fixed-top shadow">
     <div class="container">
@@ -20,37 +31,37 @@ $currentUrl = parse_url($this->serverurl(), PHP_URL_PATH);
         <div class="collapse navbar-collapse" id="navbarCollapse">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle<?= str_starts_with($currentUrl, $this->url('about.overview')) || str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>"
+                    <a class="nav-link dropdown-toggle<?= $isRouteSubpath('about.overview') || $isRouteSubpath('security') ? ' active' : '' ?>"
                        href="#"
                        data-toggle="dropdown"
                        aria-expanded="false">About</a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item<?= $currentUrl === $this->url('about.overview') ? ' active' : '' ?>" href="<?= $this->url('about.overview') ?>">Overview</a>
-                        <a class="dropdown-item<?= $currentUrl === $this->url('about.tsc') || $currentUrl === $this->url('about.join') ? ' active' : '' ?>" href="<?= $this->url('about.tsc') ?>">Technical Steering Committee</a>
-                        <a class="dropdown-item<?= $currentUrl === $this->url('about.foundation') ? ' active' : '' ?>" href="<?= $this->url('about.foundation') ?>">About the Foundation</a>
-                        <a class="dropdown-item<?= str_starts_with($currentUrl, $this->url('security')) ? ' active' : '' ?>" href="<?= $this->url('security') ?>">Security</a>
+                        <a class="dropdown-item<?= $isCurrentRoute('about.overview') ? ' active' : '' ?>" href="<?= $this->url('about.overview') ?>">Overview</a>
+                        <a class="dropdown-item<?= $isCurrentRoute('about.tsc') || $isCurrentRoute('about.join') ? ' active' : '' ?>" href="<?= $this->url('about.tsc') ?>">Technical Steering Committee</a>
+                        <a class="dropdown-item<?= $isCurrentRoute('about.foundation') ? ' active' : '' ?>" href="<?= $this->url('about.foundation') ?>">About the Foundation</a>
+                        <a class="dropdown-item<?= $isRouteSubpath('security') ? ' active' : '' ?>" href="<?= $this->url('security') ?>">Security</a>
                     </div>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link<?= str_starts_with($currentUrl, $this->url('blog')) ? ' active' : '' ?>"
+                    <a class="nav-link<?= $isRouteSubpath('blog') ? ' active' : '' ?>"
                        href="<?= $this->url('blog') ?>">Blog</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://docs.laminas.dev">Docs</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link<?= str_starts_with($currentUrl, $this->url('community.participate')) ? ' active' : '' ?>"
+                    <a class="nav-link<?= $isRouteSubpath('community.participate') ? ' active' : '' ?>"
                        href="<?= $this->url('community.participate') ?>">Community</a>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle<?= str_starts_with($currentUrl, $this->url('app.support')) || str_starts_with($currentUrl, $this->url('app.commercial-vendor-program')) ? ' active' : '' ?>"
+                    <a class="nav-link dropdown-toggle<?= $isRouteSubpath('app.support') || $isRouteSubpath('app.commercial-vendor-program') ? ' active' : '' ?>"
                        href="<?= $this->url('app.support') ?>"
                        data-toggle="dropdown"
                        aria-expanded="false">Support Laminas</a>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item<?= $currentUrl === $this->url('app.support') ? ' active' : '' ?>" href="<?= $this->url('app.support') ?>">Overview</a>
+                        <a class="dropdown-item<?= $isCurrentRoute('app.support') ? ' active' : '' ?>" href="<?= $this->url('app.support') ?>">Overview</a>
                         <a class="dropdown-item" href="https://crowdfunding.lfx.linuxfoundation.org/projects/laminas-project" target="_blank">Sponsor Laminas Development <i class="bi-box-arrow-up-right"></i></a>
-                        <a class="dropdown-item<?= $currentUrl === $this->url('app.commercial-vendor-program') ? ' active' : '' ?>" href="<?= $this->url('app.commercial-vendor-program') ?>">Commercial Vendor Program</a>
+                        <a class="dropdown-item<?= $isCurrentRoute('app.commercial-vendor-program') ? ' active' : '' ?>" href="<?= $this->url('app.commercial-vendor-program') ?>">Commercial Vendor Program</a>
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

A potential fix for issue #191 which was triggered by calling `$this->url()` when accessing a nonexistent route. The resulting exception would prevent rendering of the 404 page, so the straightforward solution was to catch the exception in the partial itself. 
