### PR TITLE
Add protections against PRs to live branch and add publish workflow

### DIFF
--- a/.github/workflows/no-pr-to-live.yml
+++ b/.github/workflows/no-pr-to-live.yml
@@ -1,0 +1,18 @@
+name: No PRs to live branch
+
+on:
+  pull_request_target:
+    branches:
+      - master
+
+jobs:
+  prevent-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close PR
+        if: github.event.action == 'opened'
+        run: |
+          gh pr close "${{ github.event.pull_request.url }}"
+            --comment "Pull requests to the live branch are not allowed. Use staging branch. Publish via workflow dispatch to Publish to live workflow"
+      - name: Fail check for branch protection rule
+        run: exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: Publish to live
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push-to-live:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          git fetch origin
+          git push origin origin/staging:master


### PR DESCRIPTION
To ensure no changes have skipped staging only fast forward pushes from staging should be used.

This PR adds protection workflow that together with branch protection rule blocks all PRs to master branch.

Additional workflow is added that performs fast forwarding push and can be triggered via web ui via workflow dispatch.