### PR TITLE
Add staging branch check for branch protection rules

### DIFF
--- a/.github/workflows/commit-in-staging.yml
+++ b/.github/workflows/commit-in-staging.yml
@@ -1,0 +1,12 @@
+name: Status check for live branch
+on:
+  push:
+    branches:
+      - staging
+
+jobs:
+  commit-in-staging:
+    name: Commit is in the staging branch
+    runs-on: ubuntu-latest
+    steps:
+        - run: exit 0

--- a/.github/workflows/pr-autocloser.yml
+++ b/.github/workflows/pr-autocloser.yml
@@ -2,6 +2,8 @@ name: No PRs to live branch
 
 on:
   pull_request_target:
+    types:
+      - opened
     branches:
       - master
 
@@ -10,9 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment and close PR
-        if: github.event.action == 'opened'
         run: |
           gh pr close "${{ github.event.pull_request.url }}"
             --comment "Pull requests to the live branch are not allowed. Use staging branch. Publish via workflow dispatch to Publish to live workflow"
-      - name: Fail check for branch protection rule
-        run: exit 1


### PR DESCRIPTION
Branch protection rules do not work exactly the way I expected them to. They block PR and they block push.

So, here is the better alternative to ensure all changes go through staging.

This workflow introduces a dummy check that runs only in staging branch and marks te commit for the branch protection rule for the master branch. That means commit that was not at the HEAD of the staging branch can not be pushed to the master.

![image](https://github.com/user-attachments/assets/fe739a28-19ad-472d-b258-f38a01331cd4)


Now, with this check in place there are two flows that can't be used together:

- fast forwarding push. Can be done via cli with `git fetch upstream && git push upstream upstream/staging:master` or via workflow dispatch to the workflow doing the same.
- pull request. Once pull request is merged history is no longer fast forwardable. All updates from staging to master MUST go via pull request.

@froschdesign which of the two you would prefer? 