### PR TITLE
Fix wrong PR url from GHA context. Improve close comment verbiage

### DIFF
--- a/.github/workflows/pr-autocloser.yml
+++ b/.github/workflows/pr-autocloser.yml
@@ -13,8 +13,11 @@ jobs:
     steps:
       - name: Comment and close PR
         run: |
-          gh pr close "${{ github.event.pull_request.url }}"
-            --comment "Pull requests to the live branch are not allowed. Use staging branch. Publish via workflow dispatch to Publish to live workflow"
+          gh pr close "${PR_NUMBER}" \
+            --repo "${GH_REPO}" \
+            --comment "Pull requests to the master branch are not allowed. Use staging branch. Maintainer can publish staging branch using workflow dispatch at https://github.com/laminas/getlaminas.org/actions/workflows/publish.yml"
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER:   ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
gh cli wants web url and I used API url for the PR.

Use repo and number instead as it is more reliable for scripted usage