### PR TITLE
Add blockquote styling for content parsing

### DIFF
--- a/src/App/ContentParser/Parser.php
+++ b/src/App/ContentParser/Parser.php
@@ -7,6 +7,7 @@ namespace App\ContentParser;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
 use League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension;
 use League\CommonMark\Extension\FrontMatter\FrontMatterExtension;
 use League\CommonMark\Extension\FrontMatter\Output\RenderedContentWithFrontMatter;
@@ -37,8 +38,11 @@ final readonly class Parser implements ParserInterface
         $environment = new Environment(
             [
                 'default_attributes' => [
-                    Table::class => [
+                    Table::class      => [
                         'class' => 'table table-striped table-bordered table-hover',
+                    ],
+                    BlockQuote::class => [
+                        'class' => 'blockquote',
                     ],
                 ],
                 'heading_permalink'  => [


### PR DESCRIPTION
Updated the `Parser.php` class to include a `blockquote` CSS class for rendering blockquote elements.

### References

- https://getbootstrap.com/docs/5.3/content/typography/#blockquotes
- https://commonmark.thephpleague.com/2.7/extensions/default-attributes/

Closes #277 