### PR TITLE
Revert renovate config to default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "forum": "https://discourse.laminas.dev"
     },
     "require": {
-        "php": "~8.4.12",
+        "php": "~8.4.0",
         "ext-curl": "*",
         "ext-pdo": "*",
         "ext-sqlite3": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83ee516efd70258ac7c57146fd1ba92f",
+    "content-hash": "b01ff638eecce3ce33c4761c6cb45a67",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -9452,7 +9452,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.4.12",
+        "php": "~8.4.0",
         "ext-curl": "*",
         "ext-pdo": "*",
         "ext-sqlite3": "*"

--- a/renovate.json
+++ b/renovate.json
@@ -6,32 +6,7 @@
   "packageRules": [
     {
       "matchDepTypes": ["require"],
-      "rangeStrategy": "bump"
-    },
-    {
-      "matchPackageNames": ["php"],
-      "rangeStrategy": "replace",
-      "groupName": "PHP"
-    },
-    {
-      "matchFiles": [".platform.app.yaml"],
-      "matchPackageNames": ["php/php-src"],
-      "extends": [":automergeDisabled", ":automergePr", ":label(Awaiting Maintainer Response)"],
-      "groupName": "PHP",
-      "commitMessageTopic": "platform.sh PHP",
-      "prBodyNotes": [
-        ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"
-      ]
-    }
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": ["^.platform.app.yaml$"],
-      "matchStrings": ["\\ntype: php:(?<currentValue>.*)\\n"],
-      "depNameTemplate": "php/php-src",
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)\\.\\d+$",
-      "versioningTemplate": "semver-coerced"
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
Clearly, renovate with this config does not work as expected. Reset it to basic config as in other repositories.

PHP in platform config is not grouped with php in composer.json
`bump` is used instead of `replace` strategy for php. `automergeDisabled` preset is overridden too.