### PR TITLE
Removes deprecated `laminasviewrenderer-js-log` package from integrations

### DIFF
--- a/data/integration/integration-packages.json
+++ b/data/integration/integration-packages.json
@@ -160,11 +160,6 @@
     "homepage": null
   },
   {
-    "packagistUrl": "https://packagist.org/packages/mimmi20/laminasviewrenderer-js-log",
-    "keywords": ["laminas-view", "js", "logger"],
-    "homepage": null
-  },
-  {
     "packagistUrl": "https://packagist.org/packages/mimmi20/mezzio-setlocale-middleware",
     "keywords": ["mezzio", "middleware", "language"],
     "homepage": null


### PR DESCRIPTION
Reference: https://packagist.org/packages/mimmi20/laminasviewrenderer-js-log